### PR TITLE
Add zipkin tracing

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,6 +16,8 @@ retrying = "*"
 "psycopg2" = "*"
 "psycopg2-binary" = "*"
 flask-httpauth = "*"
+requestsdefaulter = "*"
+flask-zipkin = "*"
 
 [dev-packages]
 testfixtures = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bc70fce7dcc51a7f5b7b2b53e63e0e55484d7ed69b696189bc5f1fe0ceabc8e3"
+            "sha256": "a6e6d71092cba4e281cd8b49bf78f04957ccfa657777317a13e6dde1676fde6b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -64,6 +64,13 @@
             "index": "pypi",
             "version": "==3.1.4"
         },
+        "certifi": {
+            "hashes": [
+                "sha256:376690d6f16d32f9d1fe8932551d80b23e9d393a8578c5633a2ed39a64861638",
+                "sha256:456048c7e371c089d0a77a5212fb37a2c2dce1e24146e3b7e0261736aaeaa22a"
+            ],
+            "version": "==2018.8.24"
+        },
         "cfenv": {
             "hashes": [
                 "sha256:7815bffcc4a3db350f92517157fafc577c11b5a7ff172dc5632f1042b93073e8",
@@ -109,6 +116,13 @@
             ],
             "version": "==1.11.5"
         },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
         "click": {
             "hashes": [
                 "sha256:29f99fc6125fbc931b758dc053b3114e55c77a6e4c6c3a2674a2dc986016381d",
@@ -132,6 +146,14 @@
             "index": "pypi",
             "version": "==3.2.4"
         },
+        "flask-zipkin": {
+            "hashes": [
+                "sha256:402bed9a98d3507d82db98a8f7437fb52ef3684af33c58a241b37779f9013d74",
+                "sha256:fbd3e3c41ceeda922701eebbfce88c8fccb7bc849289d772f5186a14a49827bd"
+            ],
+            "index": "pypi",
+            "version": "==0.0.4"
+        },
         "furl": {
             "hashes": [
                 "sha256:17654103b8d0cbe42798592db099c728165ac12057d49fe2e69de967d87bf29b"
@@ -145,6 +167,13 @@
             ],
             "index": "pypi",
             "version": "==19.9.0"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
+                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
+            ],
+            "version": "==2.7"
         },
         "itsdangerous": {
             "hashes": [
@@ -185,6 +214,13 @@
             ],
             "index": "pypi",
             "version": "==1.7.1"
+        },
+        "ply": {
+            "hashes": [
+                "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3",
+                "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"
+            ],
+            "version": "==3.11"
         },
         "psycopg2": {
             "hashes": [
@@ -258,6 +294,12 @@
             "index": "pypi",
             "version": "==2.7.5"
         },
+        "py-zipkin": {
+            "hashes": [
+                "sha256:1cbf48c8b7e5a30c36e8eb97560b81813c38af0bdb6ad901b23bdbced15a9b79"
+            ],
+            "version": "==0.13.0"
+        },
         "pycparser": {
             "hashes": [
                 "sha256:99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226"
@@ -276,6 +318,20 @@
                 "sha256:a3c066acee22a1c94f63938341d4fb374e3fdd69366ed6603d7b24bed1efc565"
             ],
             "version": "==1.0.3"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
+                "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
+            ],
+            "version": "==2.19.1"
+        },
+        "requestsdefaulter": {
+            "hashes": [
+                "sha256:5682733d391af907d8e5e95a5470b3b785275f1089a7a7113f1bb288b9d4631a"
+            ],
+            "index": "pypi",
+            "version": "==0.1.1"
         },
         "retrying": {
             "hashes": [
@@ -306,6 +362,20 @@
             "index": "pypi",
             "version": "==18.2.0"
         },
+        "thriftpy": {
+            "hashes": [
+                "sha256:309e57d97b5bfa01601393ad4f245451e989d6206a59279e56866b264a99796d"
+            ],
+            "version": "==0.3.9"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
+                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
+            ],
+            "markers": "python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.1.*' and python_version < '4' and python_version >= '2.6'",
+            "version": "==1.23"
+        },
         "werkzeug": {
             "hashes": [
                 "sha256:c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c",
@@ -320,7 +390,7 @@
                 "sha256:0312ad34fcad8fac3704d441f7b317e50af620823353ec657a53e981f92920c0",
                 "sha256:ec9ae8adaae229e4f8446952d204a3e4b5fdd2d099f9be3aaf556120135fb3ee"
             ],
-            "markers": "python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.2.*' and python_version != '3.0.*'",
+            "markers": "python_version != '3.1.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.0.*'",
             "version": "==1.2.1"
         },
         "attrs": {
@@ -424,7 +494,7 @@
                 "sha256:6e3836e39f4d36ae72840833db137f7b7d35105079aee6ec4a62d9f80d594dd1",
                 "sha256:95eb8364a4708392bae89035f45341871286a333f749c3141c20573d2b3876e1"
             ],
-            "markers": "python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.2.*' and python_version != '3.0.*'",
+            "markers": "python_version != '3.1.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.0.*'",
             "version": "==0.7.1"
         },
         "py": {
@@ -432,7 +502,7 @@
                 "sha256:06a30435d058473046be836d3fc4f27167fd84c45b99704f2fb5509ef61f9af1",
                 "sha256:50402e9d1c9005d759426988a492e0edaadb7f4e68bcddfea586bc7432d009c6"
             ],
-            "markers": "python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.2.*' and python_version != '3.0.*'",
+            "markers": "python_version != '3.1.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.0.*'",
             "version": "==1.6.0"
         },
         "pycodestyle": {
@@ -492,7 +562,7 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "markers": "python_version < '4' and python_version != '3.1.*' and python_version >= '2.6' and python_version != '3.3.*' and python_version != '3.2.*' and python_version != '3.0.*'",
+            "markers": "python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.1.*' and python_version < '4' and python_version >= '2.6'",
             "version": "==1.23"
         }
     }

--- a/config.py
+++ b/config.py
@@ -1,4 +1,5 @@
 import os
+from distutils.util import strtobool
 
 from ras_rm_auth_service.cloud.cloudfoundry import ONSCloudFoundry
 
@@ -24,6 +25,11 @@ class Config(object):
         DATABASE_URI = cf.db.credentials['uri']
     else:
         DATABASE_URI = os.getenv('DATABASE_URI', "postgres://postgres:postgres@localhost:6432/postgres")
+
+    # Zipkin
+    ZIPKIN_DISABLE = bool(strtobool(os.getenv("ZIPKIN_DISABLE", "False")))
+    ZIPKIN_DSN = os.getenv("ZIPKIN_DSN", None)
+    ZIPKIN_SAMPLE_RATE = int(os.getenv("ZIPKIN_SAMPLE_RATE", 0))
 
 
 class DevelopmentConfig(Config):

--- a/ras_rm_auth_service/logger_config.py
+++ b/ras_rm_auth_service/logger_config.py
@@ -2,12 +2,14 @@ import logging
 import os
 import sys
 
+import flask
+from flask import g
 from structlog import configure
 from structlog.stdlib import add_log_level, filter_by_level
 from structlog.processors import JSONRenderer, TimeStamper
 
 
-def logger_initial_config(service_name=None,
+def logger_initial_config(service_name=None,    # noqa: C901  pylint: disable=too-complex
                           log_level=None,
                           logger_format=None,
                           logger_date_format=None):
@@ -17,8 +19,7 @@ def logger_initial_config(service_name=None,
         log_level = os.getenv('SMS_LOG_LEVEL', 'INFO')
     if not logger_format:
         logger_format = "%(message)s"
-    if not service_name:
-        service_name = os.getenv('NAME', 'ras-frontstage')
+
     try:
         indent = int(os.getenv('JSON_INDENT_LOGGING'))
     except TypeError:
@@ -33,8 +34,21 @@ def logger_initial_config(service_name=None,
         event_dict['service'] = service_name
         return event_dict
 
+    def zipkin_ids(logger, method_name, event_dict):  # pylint: disable=unused-argument
+        event_dict['trace'] = ''
+        event_dict['span'] = ''
+        event_dict['parent'] = ''
+        if not flask.has_app_context():
+            return event_dict
+        if '_zipkin_span' not in g:
+            return event_dict
+        event_dict['span'] = g._zipkin_span.zipkin_attrs.span_id
+        event_dict['trace'] = g._zipkin_span.zipkin_attrs.trace_id
+        event_dict['parent'] = g._zipkin_span.zipkin_attrs.parent_span_id
+        return event_dict
+
     logging.basicConfig(stream=sys.stdout, level=log_level, format=logger_format)
-    configure(processors=[add_log_level, filter_by_level, add_service,
+    configure(processors=[zipkin_ids, add_log_level, filter_by_level, add_service,
                           TimeStamper(fmt=logger_date_format, utc=True, key="created_at"), JSONRenderer(indent=indent)])
     oauth_log = logging.getLogger("requests_oauthlib")
     oauth_log.addHandler(logging.NullHandler())

--- a/test/test_logger_config.py
+++ b/test/test_logger_config.py
@@ -18,8 +18,12 @@ class TestLoggerConfig(unittest.TestCase):
         logger.error('Test')
         message = l.records[0].msg
 
-        message_contents = '{\n "event": "Test",\n "level": "error",\n "service": "ras-rm-auth-service"'
-        self.assertIn(message_contents, message)
+        self.assertIn('"event": "Test",\n ', message)
+        self.assertIn('"level": "error",\n ', message)
+        self.assertIn('"service": "ras-rm-auth-service",\n ', message)
+        self.assertIn('"trace": "",\n ', message)
+        self.assertIn('"span": "",\n ', message)
+        self.assertIn('"parent": "",\n', message)
 
     @log_capture()
     def test_indent_type_error(self, l):
@@ -28,7 +32,12 @@ class TestLoggerConfig(unittest.TestCase):
         logger = wrap_logger(logging.getLogger())
         logger.error('Test')
         message = l.records[0].msg
-        self.assertIn('{"event": "Test", "level": "error", "service": "ras-rm-auth-service"', message)
+        self.assertIn('"event": "Test", ', message)
+        self.assertIn('"level": "error", ', message)
+        self.assertIn('"service": "ras-rm-auth-service", ', message)
+        self.assertIn('"trace": "", ', message)
+        self.assertIn('"span": "", ', message)
+        self.assertIn('"parent": "", ', message)
 
     @log_capture()
     def test_indent_value_error(self, l):
@@ -36,4 +45,9 @@ class TestLoggerConfig(unittest.TestCase):
         logger = wrap_logger(logging.getLogger())
         logger.error('Test')
         message = l.records[0].msg
-        self.assertIn('{"event": "Test", "level": "error", "service": "ras-rm-auth-service"', message)
+        self.assertIn('"event": "Test", ', message)
+        self.assertIn('"level": "error", ', message)
+        self.assertIn('"service": "ras-rm-auth-service", ', message)
+        self.assertIn('"trace": "", ', message)
+        self.assertIn('"span": "", ', message)
+        self.assertIn('"parent": "", ', message)


### PR DESCRIPTION
Currently there's no way to trace the requests through the application.
This will add the tracing headers to any request that comes through this
application onto another service, or preserve existing headers allowing
the user to follow requests through the application as a whole. Zipkin
ids will also be added to logs to give better insight when debugging.

Can be ran with docker dev branch https://github.com/ONSdigital/ras-rm-docker-dev/tree/add-new-auth-service