### PR TITLE
Add user migration script

### DIFF
--- a/migrations/manual_scripts/migrate_users.sql
+++ b/migrations/manual_scripts/migrate_users.sql
@@ -1,0 +1,3 @@
+INSERT INTO auth.user(id, username, hashed_password, account_verified, account_locked, failed_logins)
+SELECT id, email, password, account_is_verified, account_is_locked, failed_logins
+FROM public.credentials_oauthuser;


### PR DESCRIPTION
Added user migration script to move users from public schema
to auth schema for the new authentication service. This script
will not be ran automatically with alembic but provisioned manually.