### PR TITLE
Add missing reset failed logins

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/ONSdigital/ras-rm-auth-service/branch/master/graph/badge.svg)](https://codecov.io/gh/ONSdigital/ras-rm-auth-service)
 
 
-A replacement for the [django-oauth2-test](https://github.com/ONSdigital/django-oauth2-test)
+A drop-in replacement for the [django-oauth2-test](https://github.com/ONSdigital/django-oauth2-test)
 
 ## Setup
 Based on python 3.6


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
A missing functionality was identified where a user's failed logins
count needs to be reset if the user logs in successfully.
Also refactored authorisation logic out of the view and into the
user model class.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Added missing functionality to reset failed logins count when user successfully logs in
Refactored authorisation logic out of the view and into the user models class

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run make test

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/1NVPXyuQ/388-re-implement-missing-auth-functionality-in-ras-rm-auth-service