### PR TITLE
Add case insensitivity to email when logging in

### DIFF
--- a/ras_rm_auth_service/resources/tokens.py
+++ b/ras_rm_auth_service/resources/tokens.py
@@ -1,6 +1,7 @@
 import logging
 
 import structlog
+from sqlalchemy import func
 from flask import Blueprint, make_response, request, jsonify
 
 from ras_rm_auth_service.basic_auth import auth
@@ -30,7 +31,7 @@ def post_token():
         return make_response(jsonify({"detail": "Missing 'username' or 'password'"}), 400)
 
     with transactional_session() as session:
-        user = session.query(User).filter(User.username == username).first()
+        user = session.query(User).filter(func.lower(User.username) == func.lower(username)).first()
 
         if not user:
             logger.debug("User does not exist")

--- a/test/resources/test_tokens.py
+++ b/test/resources/test_tokens.py
@@ -45,6 +45,35 @@ class TestTokens(unittest.TestCase):
                          {"id": 895725, "access_token": "NotImplementedInAuthService", "expires_in": 3600,
                           "token_type": "Bearer", "scope": "", "refresh_token": "NotImplementedInAuthService"})
 
+    def test_verifed_user_can_login_with_case_insensitive_email(self):
+        """
+        Given a user account has been created but not verified
+        When I verify the account
+        Then I can login with a case insensitive email address
+        """
+        # Given
+        form_data = {"username": "testuser@email.com", "password": "password"}
+        self.client.post('/api/account/create',
+                         data=form_data, headers=self.headers)
+
+        # When
+
+        form_data = {"username": "testuser@email.com",
+                     "account_verified": "true"}
+        response = self.client.put(
+            '/api/account/create', data=form_data, headers=self.headers)
+
+        # Then
+        self.assertEqual(response.status_code, 201)
+
+        form_data = {"username": "TeStUsER@eMAil.com", "password": "password"}
+        response = self.client.post(
+            '/api/v1/tokens/', data=form_data, headers=self.headers)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.get_json(),
+                         {"id": 895725, "access_token": "NotImplementedInAuthService", "expires_in": 3600,
+                          "token_type": "Bearer", "scope": "", "refresh_token": "NotImplementedInAuthService"})
+
     def test_unverifed_user_cannot_login(self):
         """
         Given a user account has been created but not verified


### PR DESCRIPTION
# Motivation and Context
When logging in, the email was case sensitive, which isn't correct behaviour.

# What has changed
All that has changed is both the stored email and the supplied one are lowercased before a comparison is done.

# How to test?
Attempt to log in with randomly capitalised letters in master.  It will fail.
Do the same again with this branch checked out, it should succeed.

# Links
https://trello.com/c/elpmcVY4/797-bug-new-auth-service-email-address-is-case-sensitive-when-logging-in