### PR TITLE
Tidy tokens endpoint

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,11 +1,14 @@
 # Auth service API
- This page documents the Auth service API endpoints. Apart from the Service Information endpoint, all these endpoints 
+
+ This page documents the Auth service API endpoints. Apart from the Service Information endpoint, all these endpoints
  are secured using HTTP basic authentication.
 
 ## Service Information
+
 * `GET /info` will return information about this service, collated from when it was last built.
- 
+
 ### Example JSON Response
+
 ```json
 {
   "name": "ras-rm-auth-service",
@@ -17,15 +20,16 @@
 }
 ```
 
-
 ## create account
+
 * `POST /api/account/create` create user account
 
-**Required parameters:** 
+**Required parameters:**
 `username` user's email address.
 `password` user's password
- 
+
 ### Example JSON Request
+
 ```json
 {
   "username": "example@example.com",
@@ -34,6 +38,7 @@
 ```
 
 ### Example JSON Response
+
 ```json
 {
   "account": "example@example.com",
@@ -45,17 +50,18 @@ An `HTTP 201 OK` status code is returned if the request could be successfully pr
 An `HTTP 400 BAD REQUEST` status code is returned for bad request parameters.
 Errors if unable to create new account.
 
-
 ## update account
+
 * `PUT /api/account/create` update user account.
 
-**Required parameters:** 
+**Required parameters:**
 `username` user's email address.
 
 **Optional parameters**
 `account_verified` update user's verified status.
- 
+
 ### Example JSON Request
+
 ```json
 {
   "username": "example@example.com",
@@ -64,6 +70,7 @@ Errors if unable to create new account.
 ```
 
 ### Example JSON Response
+
 ```json
 {
   "account": "example@example.com",
@@ -71,12 +78,12 @@ Errors if unable to create new account.
 }
 ```
 
-An `HTTP 201 OK` status code is returned if the request could be successfully processed. 
+An `HTTP 201 OK` status code is returned if the request could be successfully processed.
 An `HTTP 400 BAD REQUEST` status code is returned for bad request parameters.
 An `HTTP 401 UNAUTHORIZED` status code is returned for unauthorized user credentials.
 
-
 ## verify account
+
 This endpoint came about from the old oauth2 auth service this service is replacing.  In that service, you hit the endpoint
 with the credentials and you got oauth tokens in the response.  To hasten the changeover, this endpoint was left as is, but instead
 of it returning tokens (that weren't being used by anything), we give a response with a status code of 204 to say that it was successful
@@ -84,11 +91,12 @@ but we don't need to give anything back to you.
 
 * `POST /api/v1/tokens` verify user account
 
-**Required parameters:** 
+**Required parameters:**
 `username` user's email address.
 `password` user's password
- 
+
 ### Example JSON Request
+
 ```json
 {
   "username": "example@example.com",

--- a/API.md
+++ b/API.md
@@ -77,6 +77,11 @@ An `HTTP 401 UNAUTHORIZED` status code is returned for unauthorized user credent
 
 
 ## verify account
+This endpoint came about from the old oauth2 auth service this service is replacing.  In that service, you hit the endpoint
+with the credentials and you got oauth tokens in the response.  To hasten the changeover, this endpoint was left as is, but instead
+of it returning tokens (that weren't being used by anything), we give a response with a status code of 204 to say that it was successful
+but we don't need to give anything back to you.
+
 * `POST /api/v1/tokens` verify user account
 
 **Required parameters:** 
@@ -91,17 +96,6 @@ An `HTTP 401 UNAUTHORIZED` status code is returned for unauthorized user credent
 }
 ```
 
-### Example JSON Response
-```json
-{
-  "id": 895725, 
-  "access_token": "fakefake-4bc1-4254-b43a-f44791ecec75", 
-  "expires_in": 3600,
-  "token_type": "Bearer", 
-  "scope": "", 
-  "refresh_token": "fakefake-2151-4b11-b0d5-a9a68f2c53de"
-}
-```
-
-An `HTTP 201 OK` status code is returned if the request could be successfully processed. 
+An `HTTP 204 NO CONTENT` status code is returned if the request could be successfully processed and the user credentials are correct
+An `HTTP 400 BAD REQUEST` status code is returned if the request is missing any parameters
 An `HTTP 401 UNAUTHORIZED` status code is returned for Unauthorized user credentials, unverified user and if user does not exist.

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ test: lint
 	pipenv check
 	pipenv run pytest
 
-run:
+start:
 	APP_SETTINGS=DevelopmentConfig pipenv run ./docker-entrypoint.sh
 
 docker:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ make test
 Run the server
 
 ```
-make run
+make start
 ```
 
 ## Environment Variables

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # ras-rm-auth-service
+
 [![Build Status](https://travis-ci.org/ONSdigital/ras-rm-auth-service.svg?branch=master)](https://travis-ci.org/ONSdigital/ras-rm-auth-service)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/5c72e3cdb35b487ea0f462f8b3ee4606)](https://www.codacy.com/app/sdcplatform/ras-rm-auth-service?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ONSdigital/ras-rm-auth-service&amp;utm_campaign=Badge_Grade)
 [![codecov](https://codecov.io/gh/ONSdigital/ras-rm-auth-service/branch/master/graph/badge.svg)](https://codecov.io/gh/ONSdigital/ras-rm-auth-service)
 
-
 A drop-in replacement for the [django-oauth2-test](https://github.com/ONSdigital/django-oauth2-test)
 
 ## Setup
+
 Based on python 3.6
 
 Use [Pyenv](https://github.com/pyenv/pyenv) to manage installed Python versions
@@ -22,13 +23,13 @@ pipenv install
 
 Run the tests
 
-```
+```bash
 make test
 ```
 
 Run the server
 
-```
+```bash
 make start
 ```
 
@@ -36,7 +37,7 @@ make start
 
 * `LOGGING_LEVEL`: Logging level, defaults to INFO
 * `DATABASE_URI`: Defaults to "postgresql://postgres:postgres@localhost:6432/postgres" overridden by `VCAP_SERVICES`
-* `DB_POOL_SIZE`: Configure database connection pool size, defaults to 5 
+* `DB_POOL_SIZE`: Configure database connection pool size, defaults to 5
 * `DB_MAX_OVERFLOW`: Configure database max connection pool overflow, defaults to 10
 * `SECURITY_USER_NAME`: Basic auth username
 * `SECURITY_USER_PASSWORD`: Basic auth password

--- a/ras_rm_auth_service/resources/tokens.py
+++ b/ras_rm_auth_service/resources/tokens.py
@@ -48,6 +48,4 @@ def post_token():
             logger.debug(ex.description, username=payload.get('username'))
             return make_response(jsonify({"detail": ex.description}), 401)
 
-    return make_response(
-        jsonify({"id": 895725, "access_token": "NotImplementedInAuthService", "expires_in": 3600,
-                 "token_type": "Bearer", "scope": "", "refresh_token": "NotImplementedInAuthService"}), 201)
+    return make_response('', 204)

--- a/ras_rm_auth_service/resources/tokens.py
+++ b/ras_rm_auth_service/resources/tokens.py
@@ -31,8 +31,8 @@ def post_token():
     with the same name, but instead of it returning a json payload with tokens, we decided a 204 would suffice as
     the HTTP equivalent of a thumbs up that the credentials were correct.
 
-    Once the old service has been retired, this endpoint and this services API as a whole needs to be reviewed and cleaned
-    up.
+    Once the old service has been retired, this endpoint and this services API as a whole needs to be reviewed
+    and cleaned up.
     """
     logger.info("Verifying user credentials")
     post_params = request.form

--- a/ras_rm_auth_service/resources/tokens.py
+++ b/ras_rm_auth_service/resources/tokens.py
@@ -25,6 +25,16 @@ def before_tokens_view():
 
 @tokens.route('/', methods=['POST'])
 def post_token():
+    """This endpoint looks weird because it has a history with the previous authentication service.
+    The previous one had a /tokens endpoint to provide oauth tokens for users who provided correct credentials.
+    In the changeover from the old auth service to this one, to make the changeover less risky, we kept this endpoint
+    with the same name, but instead of it returning a json payload with tokens, we decided a 204 would suffice as
+    the HTTP equivalent of a thumbs up that the credentials were correct.
+
+    Once the old service has been retired, this endpoint and this services API as a whole needs to be reviewed and cleaned
+    up.
+    """
+    logger.info("Verifying user credentials")
     post_params = request.form
 
     try:
@@ -48,4 +58,5 @@ def post_token():
             logger.debug(ex.description, username=payload.get('username'))
             return make_response(jsonify({"detail": ex.description}), 401)
 
+    logger.info("User credentials correct")
     return make_response('', 204)

--- a/ras_rm_auth_service/resources/tokens.py
+++ b/ras_rm_auth_service/resources/tokens.py
@@ -49,11 +49,7 @@ def post_token():
         user = session.query(User).filter(func.lower(User.username) == func.lower(payload.get('username'))).first()
 
         if not user:
-<<<<<<< HEAD
             bound_logger.info("User does not exist")
-=======
-            logger.info("User does not exist")
->>>>>>> origin/master
             return make_response(
                 jsonify({"detail": "Unauthorized user credentials. This user does not exist on the OAuth2 server"}),
                 401)
@@ -62,10 +58,7 @@ def post_token():
         try:
             user.authorise(payload.get('password'))
         except Unauthorized as ex:
-<<<<<<< HEAD
             bound_logger.info("User is unauthorised", description=ex.description)
-=======
->>>>>>> origin/master
             return make_response(jsonify({"detail": ex.description}), 401)
 
     logger.info("User credentials correct")

--- a/test/resources/test_account.py
+++ b/test/resources/test_account.py
@@ -237,4 +237,4 @@ class TestAccount(unittest.TestCase):
         # Then
         form_data = {"username": "testuser@email.com", "password": "password"}
         response = self.client.post('/api/v1/tokens/', data=form_data, headers=self.headers)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 204)

--- a/test/resources/test_tokens.py
+++ b/test/resources/test_tokens.py
@@ -1,7 +1,9 @@
 import base64
 import unittest
 
+import pytest
 from ras_rm_auth_service.models import models
+from ras_rm_auth_service.resources.tokens import obfuscate_email
 from run import create_app
 
 
@@ -231,3 +233,13 @@ class TestTokens(unittest.TestCase):
         # Then
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.get_json(), {"detail": "Missing 'username' or 'password'"})
+
+    @pytest.mark.parametrize('email, obfuscated_email', [
+        ('example@example.com', 'e*****e@e*********m'),
+        ('prefix@domain.co.uk', 'p****x@d*********k'),
+        ('first.name@place.gov.uk', 'f********e@p********k')
+    ])
+    @staticmethod
+    def test_obfuscate_email(email, obfuscated_email):
+        """Test obfuscate email correctly changes inputted emails"""
+        assert obfuscate_email(email) == obfuscated_email

--- a/test/resources/test_tokens.py
+++ b/test/resources/test_tokens.py
@@ -40,10 +40,7 @@ class TestTokens(unittest.TestCase):
 
         form_data = {"username": "testuser@email.com", "password": "password"}
         response = self.client.post('/api/v1/tokens/', data=form_data, headers=self.headers)
-        self.assertEqual(response.status_code, 201)
-        self.assertEqual(response.get_json(),
-                         {"id": 895725, "access_token": "NotImplementedInAuthService", "expires_in": 3600,
-                          "token_type": "Bearer", "scope": "", "refresh_token": "NotImplementedInAuthService"})
+        self.assertEqual(response.status_code, 204)
 
     def test_verifed_user_can_login_with_case_insensitive_email(self):
         """
@@ -69,10 +66,7 @@ class TestTokens(unittest.TestCase):
         form_data = {"username": "TeStUsER@eMAil.com", "password": "password"}
         response = self.client.post(
             '/api/v1/tokens/', data=form_data, headers=self.headers)
-        self.assertEqual(response.status_code, 201)
-        self.assertEqual(response.get_json(),
-                         {"id": 895725, "access_token": "NotImplementedInAuthService", "expires_in": 3600,
-                          "token_type": "Bearer", "scope": "", "refresh_token": "NotImplementedInAuthService"})
+        self.assertEqual(response.status_code, 204)
 
     def test_unverifed_user_cannot_login(self):
         """

--- a/test/resources/test_tokens.py
+++ b/test/resources/test_tokens.py
@@ -237,7 +237,12 @@ class TestTokens(unittest.TestCase):
     @pytest.mark.parametrize('email, obfuscated_email', [
         ('example@example.com', 'e*****e@e*********m'),
         ('prefix@domain.co.uk', 'p****x@d*********k'),
-        ('first.name@place.gov.uk', 'f********e@p********k')
+        ('first.name@place.gov.uk', 'f********e@p********k'),
+        ('me+addition@gmail.com', 'm*********n@g*******m'),
+        ('a.b.c.someone@example.com', 'a***********e@e*********m'),
+        ('john.smith123456@londinium.ac.co.uk', 'j**************6@l****************k'),
+        ('me!?@example.com', 'm**?@e*********m'),
+        ('m@m.com', 'm@m***m'),
     ])
     @staticmethod
     def test_obfuscate_email(email, obfuscated_email):


### PR DESCRIPTION
# Motivation and Context
The tokens endpoint sent hardcoded data that wasn't used anywhere.  This PR tidies it up whilst retaining the functionality for now.

# What has changed
The /tokens endpoint returns a 204 and no content, where it used to return a 200 with a json response that contained hardcoded values.

# How to test?
Look at the how to test part of https://github.com/ONSdigital/ras-frontstage/pull/459 for a detailed guide on how to test this

# Links
https://trello.com/c/XqLdUYwd/1032-tidy-up-tokens-endpoint-in-ras-rm-auth-service-3
