### PR TITLE
Remove name from config

### DIFF
--- a/ras_rm_auth_service/logger_config.py
+++ b/ras_rm_auth_service/logger_config.py
@@ -9,22 +9,18 @@ from structlog.stdlib import add_log_level, filter_by_level
 from structlog.processors import JSONRenderer, TimeStamper
 
 
-def logger_initial_config(service_name=None,    # noqa: C901  pylint: disable=too-complex
-                          log_level=None,
-                          logger_format=None,
-                          logger_date_format=None):
-    if not logger_date_format:
-        logger_date_format = os.getenv('LOGGING_DATE_FORMAT', "%Y-%m-%dT%H:%M%s")
+def logger_initial_config(log_level=None):
+    """Configures the logger"""
+    service_name = 'ras-rm-auth-service'
+    logger_date_format = os.getenv('LOGGING_DATE_FORMAT', "%Y-%m-%dT%H:%M%s")
+    logger_format = "%(message)s"
+
     if not log_level:
         log_level = os.getenv('SMS_LOG_LEVEL', 'INFO')
-    if not logger_format:
-        logger_format = "%(message)s"
 
     try:
         indent = int(os.getenv('JSON_INDENT_LOGGING'))
-    except TypeError:
-        indent = None
-    except ValueError:
+    except (TypeError, ValueError):
         indent = None
 
     def add_service(logger, method_name, event_dict):  # pylint: disable=unused-argument

--- a/ras_rm_auth_service/resources/info.py
+++ b/ras_rm_auth_service/resources/info.py
@@ -15,7 +15,7 @@ def get_info():
             git_info = json.loads(io.read())
 
     app_info = {
-            "name": current_app.config['NAME'],
+            "name": 'ras-rm-auth-service',
             "version": current_app.config['VERSION'],
            }
     info = dict(git_info, **app_info)

--- a/run.py
+++ b/run.py
@@ -23,8 +23,8 @@ def create_app(config=None):
 
     app_config = f"config.{config or os.environ.get('APP_SETTINGS', 'Config')}"
     app.config.from_object(app_config)
-    app.name = app.config['NAME']
-    logger_initial_config(service_name=app.config['NAME'], log_level=app.config['LOGGING_LEVEL'])
+    app.name = 'ras-rm-auth-service'
+    logger_initial_config(log_level=app.config['LOGGING_LEVEL'])
 
     app.url_map.strict_slashes = False
 

--- a/test/test_logger_config.py
+++ b/test/test_logger_config.py
@@ -20,7 +20,7 @@ class TestLoggerConfig(unittest.TestCase):
     @log_capture()
     def test_success(self, l):
         os.environ['JSON_INDENT_LOGGING'] = '1'
-        logger_initial_config(service_name='ras-rm-auth-service')
+        logger_initial_config()
         logger = wrap_logger(logging.getLogger())
         logger.error('Test')
         message = l.records[0].msg
@@ -36,7 +36,7 @@ class TestLoggerConfig(unittest.TestCase):
     @log_capture()
     def test_indent_type_error(self, l):
         os.environ['JSON_INDENT_LOGGING'] = 'abc'
-        logger_initial_config(service_name='ras-rm-auth-service')
+        logger_initial_config()
         logger = wrap_logger(logging.getLogger())
         logger.error('Test')
         message = l.records[0].msg
@@ -50,7 +50,7 @@ class TestLoggerConfig(unittest.TestCase):
     @pytest.mark.filterwarnings(f"ignore:{testfixtures_warning}")
     @log_capture()
     def test_indent_value_error(self, l):
-        logger_initial_config(service_name='ras-rm-auth-service')
+        logger_initial_config()
         logger = wrap_logger(logging.getLogger())
         logger.error('Test')
         message = l.records[0].msg


### PR DESCRIPTION
# Motivation and Context
This application has a name in the config that's not really needed.

# What has changed
The single use of NAME is now hardcoded in the info endpoint and logging configuration.

# How to test?
- Unit tests pass
- Still works locally

# Links
https://trello.com/c/rao67UDS/1011-remove-application-name-config-item-environment-variable-from-ras-repos-3