### PR TITLE
Return json if basic auth fail

### DIFF
--- a/ras_rm_auth_service/basic_auth.py
+++ b/ras_rm_auth_service/basic_auth.py
@@ -19,4 +19,5 @@ def get_pw(username):
 
 @auth.error_handler
 def auth_error():
-    return jsonify({"detail": "Incorrect basic auth"})
+    return jsonify({"title": "Basic auth error in Auth service",
+                    "detail": "Name or password incorrect"})

--- a/ras_rm_auth_service/basic_auth.py
+++ b/ras_rm_auth_service/basic_auth.py
@@ -1,4 +1,4 @@
-from flask import current_app
+from flask import current_app, jsonify
 from flask_httpauth import HTTPBasicAuth
 
 auth = HTTPBasicAuth()
@@ -15,3 +15,8 @@ def get_pw(username):
     config_password = current_app.config['SECURITY_USER_PASSWORD']
     if username == config_username:
         return config_password
+
+
+@auth.error_handler
+def auth_error():
+    return jsonify({"detail": "Incorrect basic auth"})

--- a/ras_rm_auth_service/resources/account.py
+++ b/ras_rm_auth_service/resources/account.py
@@ -30,7 +30,8 @@ def post_account():
         payload = account_schema.load(post_params)
     except ValidationError as ex:
         logger.info("Missing request parameter", exc_info=ex)
-        return make_response(jsonify({"detail": "Missing 'username' or 'password'"}), 400)
+        return make_response(jsonify({"title": "Authentication error in Auth service",
+                                      "detail": "Missing 'username' or 'password'"}), 400)
 
     try:
         with transactional_session() as session:
@@ -39,10 +40,12 @@ def post_account():
             session.add(user)
     except IntegrityError:
         logger.exception("Unable to create account with requested username")
-        return make_response(jsonify({"detail": "Unable to create account with requested username"}), 500)
+        return make_response(jsonify({"title": "Auth service account create error",
+                                      "detail": "Unable to create account with requested username"}), 500)
     except SQLAlchemyError:
         logger.exception("Unable to commit account to database")
-        return make_response(jsonify({"detail": "Unable to commit account to database"}), 500)
+        return make_response(jsonify({"title": "Auth service account create db error",
+                                      "detail": "Unable to commit account to database"}), 500)
 
     logger.info("Successfully created account", user_id=user.id)
     return make_response(jsonify({"account": user.username, "created": "success"}), 201)
@@ -56,7 +59,8 @@ def put_account():
         username = put_params['username']
     except KeyError as ex:
         logger.info("Missing request parameter", exc_info=ex)
-        return make_response(jsonify({"detail": "Missing 'username'"}), 400)
+        return make_response(jsonify({"title": "Auth service account update user error",
+                                      "detail": "Missing 'username'"}), 400)
 
     try:
         with transactional_session() as session:
@@ -65,16 +69,19 @@ def put_account():
             if not user:
                 logger.info("User does not exist")
                 return make_response(
-                    jsonify({"detail": "Unauthorized user credentials. This user does not exist on the OAuth2 server"}),
+                    jsonify({"title": "Auth service account update user error",
+                             "detail": "Unauthorized user credentials. This user does not exist on the Auth server"}),
                     401)
 
             user.update_user(put_params)
     except ValueError as ex:
         logger.info("Request param is an invalid type", exc_info=ex)
-        return make_response(jsonify({"detail": "account_verified status is invalid"}), 400)
+        return make_response(jsonify({"title": "Auth service account update user error",
+                                      "detail": "account_verified status is invalid"}), 400)
     except SQLAlchemyError:
         logger.exception("Unable to commit updated account to database")
-        return make_response(jsonify({"detail": "Unable to commit updated account to database"}), 500)
+        return make_response(jsonify({"title": "Auth service account update user error",
+                                      "detail": "Unable to commit updated account to database"}), 500)
 
     logger.info("Successfully updated account", user_id=user.id)
     return make_response(jsonify({"account": user.username, "updated": "success"}), 201)

--- a/ras_rm_auth_service/resources/tokens.py
+++ b/ras_rm_auth_service/resources/tokens.py
@@ -40,7 +40,8 @@ def post_token():
         payload = account_schema.load(post_params)
     except ValidationError as ex:
         logger.info("Missing request parameter", exc_info=ex)
-        return make_response(jsonify({"detail": "Missing 'username' or 'password'"}), 400)
+        return make_response(jsonify({"title": "Auth service tokens error",
+                                      "detail": "Missing 'username' or 'password'"}), 400)
 
     bound_logger = logger.bind(obfuscated_username=obfuscate_email(payload.get('username')))
 
@@ -51,7 +52,8 @@ def post_token():
         if not user:
             bound_logger.info("User does not exist")
             return make_response(
-                jsonify({"detail": "Unauthorized user credentials. This user does not exist on the OAuth2 server"}),
+                jsonify({"title": "Auth service tokens error",
+                         "detail": "Unauthorized user credentials. This user does not exist on the Auth server"}),
                 401)
 
         bound_logger.info("User found")
@@ -59,7 +61,8 @@ def post_token():
             user.authorise(payload.get('password'))
         except Unauthorized as ex:
             bound_logger.info("User is unauthorised", description=ex.description)
-            return make_response(jsonify({"detail": ex.description}), 401)
+            return make_response(jsonify({"title": "Auth service tokens error",
+                                          "detail": ex.description}), 401)
 
     logger.info("User credentials correct")
     return make_response('', 204)

--- a/test/resources/test_account.py
+++ b/test/resources/test_account.py
@@ -42,7 +42,8 @@ class TestAccount(unittest.TestCase):
 
         response = self.client.post('/api/account/create', data=form_data, headers=self.headers)
         self.assertEqual(response.status_code, 500)
-        self.assertEqual(response.get_json(), {"detail": "Unable to commit account to database"})
+        self.assertEqual(response.get_json(), {"title": "Auth service account create db error",
+                                               "detail": "Unable to commit account to database"})
 
     def test_user_create_email_conflict(self):
         """
@@ -59,7 +60,8 @@ class TestAccount(unittest.TestCase):
 
         # Then
         self.assertEqual(response.status_code, 500)
-        self.assertEqual(response.get_json(), {"detail": "Unable to create account with requested username"})
+        self.assertEqual(response.get_json(), {"title": "Auth service account create error",
+                                               "detail": "Unable to create account with requested username"})
 
     def test_user_create_bad_request(self):
         """
@@ -69,7 +71,8 @@ class TestAccount(unittest.TestCase):
 
         response = self.client.post('/api/account/create', data=form_data, headers=self.headers)
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.get_json(), {"detail": "Missing 'username' or 'password'"})
+        self.assertEqual(response.get_json(), {"title": "Authentication error in Auth service",
+                                               "detail": "Missing 'username' or 'password'"})
 
     def test_user_can_be_verified(self):
         """
@@ -106,8 +109,8 @@ class TestAccount(unittest.TestCase):
         # Then
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.get_json(), {
-            "detail": "Unauthorized user credentials. This user does not exist on the OAuth2 server"
-        })
+            "title": "Auth service account update user error",
+            "detail": "Unauthorized user credentials. This user does not exist on the Auth server"})
 
     def test_user_must_verify_with_true_or_false(self):
         """
@@ -137,7 +140,8 @@ class TestAccount(unittest.TestCase):
         response = self.client.put('/api/account/create', data=form_data, headers=self.headers)
 
         self.assertEqual(response.status_code, 500)
-        self.assertEqual(response.get_json(), {"detail": "Unable to commit updated account to database"})
+        self.assertEqual(response.get_json(), {"title": "Auth service account update user error",
+                                               "detail": "Unable to commit updated account to database"})
 
     def test_user_can_change_email(self):
         """
@@ -174,8 +178,8 @@ class TestAccount(unittest.TestCase):
         # Then
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.get_json(), {
-            "detail": "Unauthorized user credentials. This user does not exist on the OAuth2 server"
-        })
+            "title": "Auth service account update user error",
+            "detail": "Unauthorized user credentials. This user does not exist on the Auth server"})
 
     def test_user_change_email_conflict(self):
         """
@@ -196,7 +200,8 @@ class TestAccount(unittest.TestCase):
 
         # Then
         self.assertEqual(response.status_code, 500)
-        self.assertEqual(response.get_json(), {"detail": "Unable to commit updated account to database"})
+        self.assertEqual(response.get_json(), {"title": "Auth service account update user error",
+                                               "detail": "Unable to commit updated account to database"})
 
     def test_user_can_change_password(self):
         """

--- a/test/resources/test_tokens.py
+++ b/test/resources/test_tokens.py
@@ -234,6 +234,26 @@ class TestTokens(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.get_json(), {"detail": "Missing 'username' or 'password'"})
 
+    def test_invalid_basic_auth_user_returns_401_with_detail(self):
+        form_data = {"username": "testuser@email.com", "password": "password"}
+        auth = "notadmin:secret".encode('utf-8')
+        headers = {'Authorization': 'Basic %s' % base64.b64encode(bytes(auth)).decode("ascii")}
+
+        response = self.client.post('/api/account/create', data=form_data, headers=headers)
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.get_json(), {"detail": "Incorrect basic auth"})
+
+    def test_invalid_basic_auth_password_returns_401_with_detail(self):
+        form_data = {"username": "testuser@email.com", "password": "password"}
+        auth = "admin:notsecret".encode('utf-8')
+        headers = {'Authorization': 'Basic %s' % base64.b64encode(bytes(auth)).decode("ascii")}
+
+        response = self.client.post('/api/account/create', data=form_data, headers=headers)
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.get_json(), {"detail": "Incorrect basic auth"})
+
     @pytest.mark.parametrize('email, obfuscated_email', [
         ('example@example.com', 'e*****e@e*********m'),
         ('prefix@domain.co.uk', 'p****x@d*********k'),


### PR DESCRIPTION
# Motivation and Context
If the basic auth credentials failed then frontstage would die in a heap. This was because it was looking for json that was not present

# What has changed
Used the flask-hhtpauth package . Decared a @auth.error_handler function which now returns json with the keys that frontstage expects so that a meaningful error is logged

# How to test?
Run tests

# Links
https://trello.com/c/XpfbLBNw
