### PR TITLE
added last login date column to migration script

### DIFF
--- a/migrations/manual_scripts/add_last_login_date_column.sql
+++ b/migrations/manual_scripts/add_last_login_date_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE auth.user
+ADD last_login_date varchar(255);

--- a/migrations/manual_scripts/migrate_users.sql
+++ b/migrations/manual_scripts/migrate_users.sql
@@ -1,3 +1,3 @@
-INSERT INTO auth.user(id, username, hashed_password, account_verified, account_locked, failed_logins)
-SELECT id, email, password, account_is_verified, account_is_locked, failed_logins
+INSERT INTO auth.user(id, username, hashed_password, account_verified, account_locked, failed_logins, last_login_date)
+SELECT id, email, password, account_is_verified, account_is_locked, failed_logins, last_login_date
 FROM public.credentials_oauthuser;

--- a/migrations/manual_scripts/migrate_users.sql
+++ b/migrations/manual_scripts/migrate_users.sql
@@ -1,3 +1,3 @@
-INSERT INTO auth.user(id, username, hashed_password, account_verified, account_locked, failed_logins, last_login_date)
-SELECT id, email, password, account_is_verified, account_is_locked, failed_logins, last_login_date
+INSERT INTO auth.user(id, username, hashed_password, account_verified, account_locked, failed_logins)
+SELECT id, email, password, account_is_verified, account_is_locked, failed_logins
 FROM public.credentials_oauthuser;


### PR DESCRIPTION
# Motivation and Context
The recently merged last login date column PR failed in dev because the migration script didn't handle the new column.

# What has changed
Modified `migrate_users.sql` to add last_login_date.

# Links
[Trello card](https://trello.com/c/H2NW5jgy)