### PR TITLE
GDPR account deletion

### DIFF
--- a/_infra/helm/auth/Chart.yaml
+++ b/_infra/helm/auth/Chart.yaml
@@ -19,4 +19,4 @@ version: 1.1.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.1.1
+appVersion: 2.1.2

--- a/ras_rm_auth_scheduler_service/notify_service.py
+++ b/ras_rm_auth_scheduler_service/notify_service.py
@@ -62,7 +62,7 @@ class NotifyService:
                               error=e)
 
     def request_to_notify(self, template_name, email):
-        logger.info("Request to notify ", email=obfuscate_email(email), template_name=template_name)
+        logger.info("Request to notify ", template_name=template_name)
         template_id = self._get_template_id(template_name)
         first_name = self._get_user_first_name(email)
         self._send_message(email, template_id, {'FIRST_NAME': first_name})

--- a/ras_rm_auth_scheduler_service/notify_service.py
+++ b/ras_rm_auth_scheduler_service/notify_service.py
@@ -5,6 +5,7 @@ from google.cloud import pubsub_v1
 
 import config as cfg
 from ras_rm_auth_scheduler_service.logger import logger
+from ras_rm_auth_service.resources.tokens import obfuscate_email
 
 
 class NotifyService:
@@ -61,7 +62,7 @@ class NotifyService:
                               error=e)
 
     def request_to_notify(self, template_name, email):
-        logger.info("Request to notify ", email=email, template_name=template_name)
+        logger.info("Request to notify ", email=obfuscate_email(email), template_name=template_name)
         template_id = self._get_template_id(template_name)
         first_name = self._get_user_first_name(email)
         self._send_message(email, template_id, {'FIRST_NAME': first_name})

--- a/ras_rm_auth_scheduler_service/notify_service.py
+++ b/ras_rm_auth_scheduler_service/notify_service.py
@@ -5,7 +5,6 @@ from google.cloud import pubsub_v1
 
 import config as cfg
 from ras_rm_auth_scheduler_service.logger import logger
-from ras_rm_auth_service.resources.tokens import obfuscate_email
 
 
 class NotifyService:

--- a/ras_rm_auth_scheduler_service/process_due_deletion_notification_job.py
+++ b/ras_rm_auth_scheduler_service/process_due_deletion_notification_job.py
@@ -5,6 +5,7 @@ from ras_rm_auth_scheduler_service.db import setup
 from ras_rm_auth_scheduler_service.helper import get_query
 from ras_rm_auth_scheduler_service.logger import logger
 from ras_rm_auth_scheduler_service.notify_service import NotifyService
+from ras_rm_auth_service.resources.tokens import obfuscate_email
 
 
 def _get_notification_column(template_name):
@@ -25,14 +26,14 @@ def process_notification_job(date_one, date_two, scheduler):
     csr.execute(query)
     users = [x for x in chain.from_iterable(csr.fetchall()) if isinstance(x, str)]
     for username in users:
-        logger.info(f"Sending due deletion {scheduler} to {username}")
+        logger.info(f"Sending due deletion {scheduler} to {obfuscate_email(username)}")
         NotifyService().request_to_notify(template_name=scheduler,
                                           email=username)
-        logger.info(f"Due deletion {scheduler} sent to {username}")
-        logger.info(f"updating {column_name} for {username}")
+        logger.info(f"Due deletion {scheduler} sent to {obfuscate_email(username)}")
+        logger.info(f"updating {column_name} for {obfuscate_email(username)}")
         csr.execute(
-            f"Update auth.user set {column_name} = '{datetime.utcnow()}' where auth.user.username = '{username}'")
+            f"Update auth.user set {column_name} = '{datetime.utcnow()}' where auth.user.username = '{obfuscate_email(username)}'")
         con.commit()
-        logger.info(f"updated {column_name} for {username}")
+        logger.info(f"updated {column_name} for {obfuscate_email(username)}")
     csr.close()
     con.close()

--- a/ras_rm_auth_scheduler_service/process_due_deletion_notification_job.py
+++ b/ras_rm_auth_scheduler_service/process_due_deletion_notification_job.py
@@ -5,7 +5,6 @@ from ras_rm_auth_scheduler_service.db import setup
 from ras_rm_auth_scheduler_service.helper import get_query
 from ras_rm_auth_scheduler_service.logger import logger
 from ras_rm_auth_scheduler_service.notify_service import NotifyService
-from ras_rm_auth_service.resources.tokens import obfuscate_email
 
 
 def _get_notification_column(template_name):

--- a/ras_rm_auth_scheduler_service/process_due_deletion_notification_job.py
+++ b/ras_rm_auth_scheduler_service/process_due_deletion_notification_job.py
@@ -26,15 +26,14 @@ def process_notification_job(date_one, date_two, scheduler):
     csr.execute(query)
     users = [x for x in chain.from_iterable(csr.fetchall()) if isinstance(x, str)]
     for username in users:
-        obs_username = obfuscate_email(username)
-        logger.info(f"Sending due deletion {scheduler} to {obs_username}")
+        logger.info(f"Sending due deletion {scheduler} to user")
         NotifyService().request_to_notify(template_name=scheduler,
                                           email=username)
-        logger.info(f"Due deletion {scheduler} sent to {obs_username}")
-        logger.info(f"updating {column_name} for {obs_username}")
+        logger.info(f"Due deletion {scheduler} sent to user")
+        logger.info(f"updating {column_name} for user")
         csr.execute(
             f"Update auth.user set {column_name} = '{datetime.utcnow()}' where auth.user.username = '{username}'")
         con.commit()
-        logger.info(f"updated {column_name} for {obs_username}")
+        logger.info(f"updated {column_name} for user")
     csr.close()
     con.close()

--- a/ras_rm_auth_scheduler_service/process_due_deletion_notification_job.py
+++ b/ras_rm_auth_scheduler_service/process_due_deletion_notification_job.py
@@ -26,14 +26,15 @@ def process_notification_job(date_one, date_two, scheduler):
     csr.execute(query)
     users = [x for x in chain.from_iterable(csr.fetchall()) if isinstance(x, str)]
     for username in users:
-        logger.info(f"Sending due deletion {scheduler} to {obfuscate_email(username)}")
+        obs_username = obfuscate_email(username)
+        logger.info(f"Sending due deletion {scheduler} to {obs_username}")
         NotifyService().request_to_notify(template_name=scheduler,
                                           email=username)
-        logger.info(f"Due deletion {scheduler} sent to {obfuscate_email(username)}")
-        logger.info(f"updating {column_name} for {obfuscate_email(username)}")
+        logger.info(f"Due deletion {scheduler} sent to {obs_username}")
+        logger.info(f"updating {column_name} for {obs_username}")
         csr.execute(
-            f"Update auth.user set {column_name} = '{datetime.utcnow()}' where auth.user.username = '{obfuscate_email(username)}'")
+            f"Update auth.user set {column_name} = '{datetime.utcnow()}' where auth.user.username = '{obs_username}'")
         con.commit()
-        logger.info(f"updated {column_name} for {obfuscate_email(username)}")
+        logger.info(f"updated {column_name} for {obs_username}")
     csr.close()
     con.close()

--- a/ras_rm_auth_scheduler_service/process_due_deletion_notification_job.py
+++ b/ras_rm_auth_scheduler_service/process_due_deletion_notification_job.py
@@ -33,7 +33,7 @@ def process_notification_job(date_one, date_two, scheduler):
         logger.info(f"Due deletion {scheduler} sent to {obs_username}")
         logger.info(f"updating {column_name} for {obs_username}")
         csr.execute(
-            f"Update auth.user set {column_name} = '{datetime.utcnow()}' where auth.user.username = '{obs_username}'")
+            f"Update auth.user set {column_name} = '{datetime.utcnow()}' where auth.user.username = '{username}'")
         con.commit()
         logger.info(f"updated {column_name} for {obs_username}")
     csr.close()

--- a/ras_rm_auth_service/models/models.py
+++ b/ras_rm_auth_service/models/models.py
@@ -98,6 +98,15 @@ class User(Base):
         self.second_notification = None
         self.third_notification = None
 
+    def to_user_dict(self):
+        d = {
+            'first_notification': self.first_notification,
+            'second_notification': self.second_notification,
+            'third_notification': self.third_notification,
+            'mark_for_deletion': self.mark_for_deletion
+        }
+        return d
+
 
 class AccountSchema(Schema):
     """ Account data which is required for the operation of runner itself

--- a/ras_rm_auth_service/models/models.py
+++ b/ras_rm_auth_service/models/models.py
@@ -61,6 +61,7 @@ class User(Base):
         self.reset_failed_logins()
         self.account_locked = False
         self.account_verified = True
+        self.mark_for_deletion = False
 
     def set_hashed_password(self, string_password):
         logger.info("Changing password for account", user_id=id)
@@ -94,6 +95,7 @@ class User(Base):
         self.last_login_date = datetime.now(timezone.utc)
 
     def reset_due_deletion_dates(self):
+        self.mark_for_deletion = False
         self.first_notification = None
         self.second_notification = None
         self.third_notification = None
@@ -107,9 +109,18 @@ class User(Base):
         }
         return d
 
+    def patch_user(self, patch_params):
+        self.mark_for_deletion = patch_params.get('mark_for_deletion', self.mark_for_deletion)
+
 
 class AccountSchema(Schema):
     """ Account data which is required for the operation of runner itself
     """
     username = fields.String(required=True, validate=validate.Length(min=1))
     password = fields.String(required=True, validate=validate.Length(min=1))
+
+
+class PatchAccountSchema(Schema):
+    """ Account data which is required for the operation patch
+    """
+    mark_for_deletion = fields.Boolean(required=True)

--- a/test/resources/test_account.py
+++ b/test/resources/test_account.py
@@ -1,5 +1,4 @@
 import base64
-import json
 import unittest
 from unittest.mock import patch
 

--- a/test/resources/test_account.py
+++ b/test/resources/test_account.py
@@ -334,9 +334,9 @@ class TestAccount(unittest.TestCase):
         form_data = {"username": "testuser@email.com", "password": "password"}
         self.client.post('/api/account/create', data=form_data, headers=self.headers)
         # When
-        response = self.client.get('/api/account/users/username', json={'username': "testuser@email.com"},
-                                   headers=self.headers)
+        response = self.client.get('/api/account/user/testuser@email.com', headers=self.headers)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['mark_for_deletion'], False)
 
     def test_user_account_that_does_not_exist(self):
         """
@@ -351,7 +351,7 @@ class TestAccount(unittest.TestCase):
         self.assertEqual(response.status_code, 401)
 
         # When
-        response = self.client.get('/api/account/users/username', json={'username': "idonotexist@example.com"},
+        response = self.client.get('/api/account/user/idonotexist@example.com',
                                    headers=self.headers)
 
         # Then
@@ -363,14 +363,12 @@ class TestAccount(unittest.TestCase):
         """
         Test get user end point with bad request
         """
-        response = self.client.get('/api/account/users/username', json={},
+        response = self.client.get('/api/account/user/',
                                    headers=self.headers)
 
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.get_json(), {"title": "Auth service get user error",
-                                               "detail": "Missing 'username'"})
+        self.assertEqual(response.status_code, 405)
 
-    def test_undo_delete_user_account(self):
+    def test_patch_user_account(self):
         """
         Test undo delete user end point
         """
@@ -379,17 +377,18 @@ class TestAccount(unittest.TestCase):
         self.client.post('/api/account/create', data=form_data, headers=self.headers)
         self.client.delete('/api/account/user', data=form_data, headers=self.headers)
         # When
-        response = self.client.get('/api/account/users/username', json={'username': "testuser@email.com"},
+        response = self.client.get('/api/account/user/testuser@email.com',
                                    headers=self.headers)
         self.assertEqual(response.get_json()['mark_for_deletion'], True)
+        form_data_new = {"mark_for_deletion": False}
         # Then
-        upsert = self.client.patch('/api/account/user', data=form_data, headers=self.headers)
+        upsert = self.client.patch('/api/account/user/testuser@email.com', data=form_data_new, headers=self.headers)
         self.assertEqual(upsert.status_code, 204)
-        new_response = self.client.get('/api/account/users/username', json={'username': "testuser@email.com"},
+        new_response = self.client.get('/api/account/user/testuser@email.com',
                                        headers=self.headers)
         self.assertEqual(new_response.get_json()['mark_for_deletion'], False)
 
-    def test_undo_delete_user_that_does_not_exist(self):
+    def test_patch_user_that_does_not_exist(self):
         """
         Given no user account exist
         When patch a non-existing the account
@@ -402,22 +401,25 @@ class TestAccount(unittest.TestCase):
         self.assertEqual(response.status_code, 401)
 
         # When
-        response = self.client.patch('/api/account/user', data=data, headers=self.headers)
+        form_data_new = {"mark_for_deletion": False}
+        response = self.client.patch('/api/account/user/idonotexist@example.com', data=form_data_new,
+                                     headers=self.headers)
 
         # Then
         self.assertEqual(response.status_code, 404)
         self.assertEqual(response.get_json(), {"title": "Auth service undo delete user error",
                                                "detail": "This user does not exist on the Auth server"})
 
-    def test_undo_delete_user_bad_request(self):
+    def test_patch_user_bad_request(self):
         """
         Test patch user end point with bad request
         """
-        response = self.client.patch('/api/account/user', data={}, headers=self.headers)
+        response = self.client.patch('/api/account/user/idonotexist@example.com', data={"something": "something"},
+                                     headers=self.headers)
 
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.get_json(), {"title": "Auth service undo delete user error",
-                                               "detail": "Missing 'username'"})
+        self.assertEqual(response.get_json(), {"title": "Bad Request error in Auth service",
+                                               "detail": "Patch data validation failed"})
 
     @patch('ras_rm_auth_service.resources.account.transactional_session')
     def test_undo_delete_user_unable_to_commit(self, session_scope_mock):
@@ -425,9 +427,9 @@ class TestAccount(unittest.TestCase):
         Test patch user end point unable to commit account
         """
         session_scope_mock.side_effect = SQLAlchemyError()
-        form_data = {"username": "testuser@email.com"}
+        form_data = {"mark_for_deletion": False}
 
-        response = self.client.patch('/api/account/user', data=form_data, headers=self.headers)
+        response = self.client.patch('/api/account/user/idonotexist@example.com', data=form_data, headers=self.headers)
         self.assertEqual(response.status_code, 500)
         self.assertEqual(response.get_json(), {"title": "Auth service undo delete user error",
                                                "detail": "Unable to commit undo delete operation"})

--- a/test/resources/test_account.py
+++ b/test/resources/test_account.py
@@ -1,4 +1,5 @@
 import base64
+import json
 import unittest
 from unittest.mock import patch
 
@@ -321,3 +322,113 @@ class TestAccount(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
         self.assertEqual(response.get_json(), {"title": "Auth service delete user error",
                                                "detail": "This user does not exist on the Auth server"})
+
+    def test_get_user_account(self):
+        """
+        Test get user end point
+
+                Given a user exists
+                When get user account
+                Then account should be retrieved
+        """
+        # Given
+        form_data = {"username": "testuser@email.com", "password": "password"}
+        self.client.post('/api/account/create', data=form_data, headers=self.headers)
+        # When
+        response = self.client.get('/api/account/users/username', json={'username': "testuser@email.com"},
+                                   headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+
+    def test_user_account_that_does_not_exist(self):
+        """
+        Given no user account exist
+        When get a non-existing the account
+        Then get an error
+        """
+        # Given
+        # Verify the user doesn't exist by trying to change one that doesn't exist.
+        data = {"username": "idonotexist@example.com", "password": "password"}
+        response = self.client.put('/api/account/create', data=data, headers=self.headers)
+        self.assertEqual(response.status_code, 401)
+
+        # When
+        response = self.client.get('/api/account/users/username', json={'username': "idonotexist@example.com"},
+                                   headers=self.headers)
+
+        # Then
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.get_json(), {"title": "Auth service get user error",
+                                               "detail": "This user does not exist on the Auth server"})
+
+    def test_user_account_bad_request(self):
+        """
+        Test get user end point with bad request
+        """
+        response = self.client.get('/api/account/users/username', json={},
+                                   headers=self.headers)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json(), {"title": "Auth service get user error",
+                                               "detail": "Missing 'username'"})
+
+    def test_undo_delete_user_account(self):
+        """
+        Test undo delete user end point
+        """
+        # Given
+        form_data = {"username": "testuser@email.com", "password": "password"}
+        self.client.post('/api/account/create', data=form_data, headers=self.headers)
+        self.client.delete('/api/account/user', data=form_data, headers=self.headers)
+        # When
+        response = self.client.get('/api/account/users/username', json={'username': "testuser@email.com"},
+                                   headers=self.headers)
+        self.assertEqual(response.get_json()['mark_for_deletion'], True)
+        # Then
+        upsert = self.client.patch('/api/account/user', data=form_data, headers=self.headers)
+        self.assertEqual(upsert.status_code, 204)
+        new_response = self.client.get('/api/account/users/username', json={'username': "testuser@email.com"},
+                                       headers=self.headers)
+        self.assertEqual(new_response.get_json()['mark_for_deletion'], False)
+
+    def test_undo_delete_user_that_does_not_exist(self):
+        """
+        Given no user account exist
+        When patch a non-existing the account
+        Then get an error
+        """
+        # Given
+        # Verify the user doesn't exist by trying to change one that doesn't exist.
+        data = {"username": "idonotexist@example.com", "password": "password"}
+        response = self.client.put('/api/account/create', data=data, headers=self.headers)
+        self.assertEqual(response.status_code, 401)
+
+        # When
+        response = self.client.patch('/api/account/user', data=data, headers=self.headers)
+
+        # Then
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.get_json(), {"title": "Auth service undo delete user error",
+                                               "detail": "This user does not exist on the Auth server"})
+
+    def test_undo_delete_user_bad_request(self):
+        """
+        Test patch user end point with bad request
+        """
+        response = self.client.patch('/api/account/user', data={}, headers=self.headers)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json(), {"title": "Auth service undo delete user error",
+                                               "detail": "Missing 'username'"})
+
+    @patch('ras_rm_auth_service.resources.account.transactional_session')
+    def test_undo_delete_user_unable_to_commit(self, session_scope_mock):
+        """
+        Test patch user end point unable to commit account
+        """
+        session_scope_mock.side_effect = SQLAlchemyError()
+        form_data = {"username": "testuser@email.com"}
+
+        response = self.client.patch('/api/account/user', data=form_data, headers=self.headers)
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.get_json(), {"title": "Auth service undo delete user error",
+                                               "detail": "Unable to commit undo delete operation"})


### PR DESCRIPTION
# Motivation and Context
To support single user account deletion from response operation UI.

# What has changed
> Two endpoints has been added to 
   * `get` the user account current status
   * `patch` to undo mark for deletion

# How to test?
Smoke Test
# Links
[Trello](https://trello.com/c/eg9lY2nj/12-s20-gdpr-retention-manual-account-deletion-process-following-respondent-request-8)
