### PR TITLE
Gdpr account del 80 hr

### DIFF
--- a/_infra/helm/auth/Chart.yaml
+++ b/_infra/helm/auth/Chart.yaml
@@ -19,4 +19,4 @@ version: 1.1.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.1.2
+appVersion: 2.1.3

--- a/ras_rm_auth_service/batch_process_endpoints.py
+++ b/ras_rm_auth_service/batch_process_endpoints.py
@@ -58,6 +58,8 @@ def mark_for_deletion_accounts():
     try:
         with transactional_session() as session:
             logger.info("Scheduler processing Accounts not accessed in the last 36 months ")
+            # process to mark account ready for deletion for
+            # accounts not accessed in the last 36 months
             _since_36_months = datetime.utcnow() - timedelta(days=1095)
             _last_login_before_36_months = session.query(User).filter(and_(
                 User.last_login_date != None,  # noqa
@@ -70,6 +72,8 @@ def mark_for_deletion_accounts():
             ))
             _account_created_before_36_months.update({'mark_for_deletion': True})
             logger.info("Scheduler finished processing Accounts not accessed in last 36 months")
+            # process to mark account ready for deletion for
+            # accounts not been activated in the last 80 hrs.
             logger.info("Scheduler processing Account not activated for more than 80 hrs")
             _since_80_hrs = datetime.utcnow() - timedelta(hours=80)
             _account_not_activated_80_hrs = session.query(User).filter(and_(

--- a/ras_rm_auth_service/batch_process_endpoints.py
+++ b/ras_rm_auth_service/batch_process_endpoints.py
@@ -70,7 +70,14 @@ def mark_for_deletion_accounts():
             ))
             _account_created_before_36_months.update({'mark_for_deletion': True})
             logger.info("Scheduler finished processing Accounts not accessed in last 36 months")
-
+            logger.info("Scheduler processing Account not activated for more than 80 hrs")
+            _since_80_hrs = datetime.utcnow() - timedelta(hours=80)
+            _account_not_activated_80_hrs = session.query(User).filter(and_(
+                User.account_verified == False,  # noqa
+                User.account_creation_date < _since_80_hrs
+            ))
+            _account_not_activated_80_hrs.update({'mark_for_deletion': True})
+            logger.info("Scheduler finished* processing Account not activated for more than 80 hrs")
     except SQLAlchemyError:
         logger.exception("Unable to perform scheduler mark for delete operation")
         return make_response(jsonify({"title": "Scheduler operation for mark for delete users error",

--- a/ras_rm_auth_service/models/models.py
+++ b/ras_rm_auth_service/models/models.py
@@ -61,6 +61,7 @@ class User(Base):
         self.reset_failed_logins()
         self.account_locked = False
         self.account_verified = True
+        self.mark_for_deletion = False
 
     def set_hashed_password(self, string_password):
         logger.info("Changing password for account", user_id=id)
@@ -86,14 +87,15 @@ class User(Base):
 
         self.reset_failed_logins()
         self.update_last_login_date()
-        self.reset_due_deletion_dates()
+        self.reset_due_deletion()
 
         return True
 
     def update_last_login_date(self):
         self.last_login_date = datetime.now(timezone.utc)
 
-    def reset_due_deletion_dates(self):
+    def reset_due_deletion(self):
+        self.mark_for_deletion = False
         self.first_notification = None
         self.second_notification = None
         self.third_notification = None

--- a/test/test_batch_process_endpoints.py
+++ b/test/test_batch_process_endpoints.py
@@ -236,6 +236,7 @@ class TestBatchProcessEndpoints(unittest.TestCase):
         self.update_test_data(self.user_0, criteria)
         self.update_test_data(self.user_2, criteria)
         self.update_test_data(self.user_2, {'last_login_date': datetime.datetime.utcnow()})
+        self.update_test_data(self.user_2, {'account_verified': True})
         self.client.delete('/api/batch/account/users/mark-for-deletion', headers=self.headers)
         # Then:
         self.assertTrue(self.is_user_marked_for_deletion(self.user_0))

--- a/test/test_batch_process_endpoints.py
+++ b/test/test_batch_process_endpoints.py
@@ -1,14 +1,20 @@
 import base64
-import unittest
 import datetime
-from unittest.mock import patch
-from collections import namedtuple
+import unittest
+from unittest.mock import patch, MagicMock, PropertyMock
 from ras_rm_auth_service.models import models
 from sqlalchemy.exc import SQLAlchemyError
 
 from ras_rm_auth_service.db_session_handlers import transactional_session
 from ras_rm_auth_service.models.models import User
-from run import create_app
+from run import create_app, app
+
+
+def mock_response():
+    mock_res = MagicMock()
+    type(mock_res).status_code = PropertyMock(return_value=207)
+    mock_res.json.return_value = "{}"
+    return mock_res
 
 
 class TestBatchProcessEndpoints(unittest.TestCase):
@@ -21,6 +27,7 @@ class TestBatchProcessEndpoints(unittest.TestCase):
     form_data_1 = {"username": user_1, "password": pwd}
     form_data_2 = {"username": user_2, "password": pwd}
     form_data_3 = {"username": user_3, "password": pwd}
+    ci_upload_url = f'{app.config["PARTY_URL"]}/party-api/v1/batch/requests'
 
     def setUp(self):
         self.app = create_app('TestingConfig')
@@ -90,7 +97,17 @@ class TestBatchProcessEndpoints(unittest.TestCase):
 
     def test_batch_delete(self):
         """
-        Test bach delete
+        Test bach delete endpoint @batch.route('/users', methods=['DELETE'])
+        Given:
+        Four user exists in the system
+        When:
+        Three of the users are marked ready for deletion &
+        Scheduler calls the batch endpoint for hard delete
+        Then:
+        Once the scheduler finishes three users who were marked for deletion
+        does not exist in the system &
+        One user who was not marked for the deletion, exist in the system
+        And a request to partysvc was made to mark the users being deleted ready for deletion
         """
         # Given:
         self.batch_setup()
@@ -104,17 +121,16 @@ class TestBatchProcessEndpoints(unittest.TestCase):
         self.client.delete('/api/account/user',
                            data={"username": self.user_3},
                            headers=self.headers)
-        # Then:
-
         self.assertTrue(self.is_user_marked_for_deletion(self.user_0))
         self.assertTrue(self.is_user_marked_for_deletion(self.user_1))
         self.assertTrue(self.is_user_marked_for_deletion(self.user_3))
         self.assertFalse(self.is_user_marked_for_deletion(self.user_2))
-        fake_response = namedtuple('Response', 'status_code json')
-        with patch('ras_rm_auth_service.batch_process_endpoints.requests') as mock_request:
-            mock_request().post.return_value = fake_response(status_code=207, json=lambda: [])
+        with patch('ras_rm_auth_service.batch_process_endpoints.requests.post') as mock_request:
+            mock_request.return_value = mock_response()
             batch_delete_request = self.client.delete('/api/batch/account/users', headers=self.headers)
-            mock_request.post().assert_called_once
+            self.assertTrue(mock_request.called)
+            self.assertEqual(1, mock_request.call_count)
+        # Then:
         self.assertEqual(batch_delete_request.status_code, 204)
         self.assertTrue(self.does_user_exists(self.user_2))
         self.assertFalse(self.does_user_exists(self.user_0))
@@ -123,17 +139,24 @@ class TestBatchProcessEndpoints(unittest.TestCase):
 
     def test_batch_delete_with_out_users_marked_for_deletion(self):
         """
-        Test Batch delete
+        Test Batch delete endpoint @batch.route('/users', methods=['DELETE'])
+        Given:
+        Four user exists in the system
+        When:
+        None of the users are marked ready for deletion &
+        Scheduler calls the batch endpoint for hard delete
+        Then:
+        All four users are present in the system
         """
         # Given:
         self.batch_setup()
         # When:
-        fake_response = namedtuple('Response', 'status_code json')
-        with patch('ras_rm_auth_service.batch_process_endpoints.requests') as mock_request:
-            mock_request().post.return_value = fake_response(status_code=207, json=lambda: [])
+        with patch('ras_rm_auth_service.batch_process_endpoints.requests.post') as mock_request:
+            mock_request.return_value = mock_response()
             batch_delete_request = self.client.delete('/api/batch/account/users', headers=self.headers)
             # Then:
-            mock_request.post().assert_called_once
+            self.assertFalse(mock_request.called)
+            self.assertEqual(0, mock_request.call_count)
         self.assertEqual(batch_delete_request.status_code, 204)
         self.assertTrue(self.does_user_exists(self.user_2))
         self.assertTrue(self.does_user_exists(self.user_0))
@@ -142,6 +165,15 @@ class TestBatchProcessEndpoints(unittest.TestCase):
 
     @patch('ras_rm_auth_service.batch_process_endpoints.transactional_session')
     def test_batch_delete_users_unable_to_commit(self, session_scope_mock):
+        """
+        Test Batch delete endpoint @batch.route('/users', methods=['DELETE'])
+        Given:
+        side effect has been configured
+        When:
+        Scheduler calls the batch endpoint for hard delete
+        Then:
+        500 error is raised
+        """
         # Given:
         session_scope_mock.side_effect = SQLAlchemyError()
         form_data = {"username": "testuser@email.com"}
@@ -153,6 +185,11 @@ class TestBatchProcessEndpoints(unittest.TestCase):
                                                "detail": "Unable to perform delete operation"})
 
     def test_batch_delete_users_mark_for_deletion_when_last_login_is_not_null(self):
+        """
+        Test mark for deletion endpoint @batch.route('users/mark-for-deletion', methods=['DELETE'])
+        Provided the last login date is not null and the user has not logged in for the last
+        36 months the accounts will be marked for deletion
+        """
         # Given:
         self.batch_setup()
         # When:
@@ -168,7 +205,9 @@ class TestBatchProcessEndpoints(unittest.TestCase):
 
     def test_batch_delete_users_mark_for_deletion_when_last_login_is_null(self):
         """
-          Test scheduler endpoint for the account not accessed in the last 36 months
+        Test mark for deletion endpoint @batch.route('users/mark-for-deletion', methods=['DELETE'])
+        Provided the last login is null and the user account got created
+        36 months ago the accounts will be marked for deletion
         """
         # Given:
         self.batch_setup()
@@ -185,7 +224,10 @@ class TestBatchProcessEndpoints(unittest.TestCase):
 
     def test_batch_delete_users_mark_for_deletion_when_last_login_is_present(self):
         """
-          Test scheduler endpoint for the account not accessed in the last 36 months
+        Test mark for deletion endpoint @batch.route('users/mark-for-deletion', methods=['DELETE'])
+        Provided the last login date is present and the user account creation is present
+        users has not logged in for the last
+        36 months the accounts will be marked for deletion
         """
         # Given:
         self.batch_setup()
@@ -198,5 +240,70 @@ class TestBatchProcessEndpoints(unittest.TestCase):
         # Then:
         self.assertTrue(self.is_user_marked_for_deletion(self.user_0))
         self.assertFalse(self.is_user_marked_for_deletion(self.user_2))
+        self.assertFalse(self.is_user_marked_for_deletion(self.user_1))
+        self.assertFalse(self.is_user_marked_for_deletion(self.user_3))
+
+    def test_batch_delete_users_mark_for_deletion_for_not_verified_account(self):
+        """
+        Test mark for deletion endpoint @batch.route('users/mark-for-deletion', methods=['DELETE'])
+        Provided the account has been created 80 hrs ago but the account is not verified, the account
+        will be marked for deletion to be picked up for hard delete
+        """
+        # Given:
+        self.batch_setup()
+        # When:
+        criteria = {'account_creation_date': datetime.datetime.utcnow() - datetime.timedelta(hours=80)}
+        self.update_test_data(self.user_0, criteria)
+        self.update_test_data(self.user_2, criteria)
+        self.client.delete('/api/batch/account/users/mark-for-deletion', headers=self.headers)
+        # Then:
+        self.assertTrue(self.is_user_marked_for_deletion(self.user_0))
+        self.assertTrue(self.is_user_marked_for_deletion(self.user_2))
+        self.assertFalse(self.is_user_marked_for_deletion(self.user_1))
+        self.assertFalse(self.is_user_marked_for_deletion(self.user_3))
+
+    def test_batch_delete_users_mark_for_deletion_for_verified_account(self):
+        """
+        Test mark for deletion endpoint @batch.route('users/mark-for-deletion', methods=['DELETE'])
+        Provided the account has been created 80 hrs ago but the account is verified, the account
+        will not be marked for deletion to be picked up for hard delete
+        """
+        # Given:
+        self.batch_setup()
+        # When:
+        criteria = {'account_creation_date': datetime.datetime.utcnow() - datetime.timedelta(hours=80)}
+        self.update_test_data(self.user_0, criteria)
+        self.update_test_data(self.user_2, criteria)
+        criteria = {'account_verified': True}
+        self.update_test_data(self.user_0, criteria)
+        self.update_test_data(self.user_2, criteria)
+        self.client.delete('/api/batch/account/users/mark-for-deletion', headers=self.headers)
+        # Then:
+        self.assertFalse(self.is_user_marked_for_deletion(self.user_0))
+        self.assertFalse(self.is_user_marked_for_deletion(self.user_2))
+        self.assertFalse(self.is_user_marked_for_deletion(self.user_1))
+        self.assertFalse(self.is_user_marked_for_deletion(self.user_3))
+
+    def test_account_marked_for_deletion_resets_when_user_login(self):
+        """
+        Provided the accounts has been marked for deletion, when the user login
+        the mark_for_deletion should reset
+        """
+        # Given:
+        self.batch_setup()
+        criteria = {'account_creation_date': datetime.datetime.utcnow() - datetime.timedelta(hours=80)}
+        self.update_test_data(self.user_0, criteria)
+        self.update_test_data(self.user_2, criteria)
+        self.client.delete('/api/batch/account/users/mark-for-deletion', headers=self.headers)
+        self.assertTrue(self.is_user_marked_for_deletion(self.user_0))
+        self.assertTrue(self.is_user_marked_for_deletion(self.user_2))
+        self.assertFalse(self.is_user_marked_for_deletion(self.user_1))
+        self.assertFalse(self.is_user_marked_for_deletion(self.user_3))
+        # When:
+        form_data = {"username": self.user_0, "account_verified": "true"}
+        self.client.put('/api/account/create', data=form_data, headers=self.headers)
+        # Then:
+        self.assertFalse(self.is_user_marked_for_deletion(self.user_0))
+        self.assertTrue(self.is_user_marked_for_deletion(self.user_2))
         self.assertFalse(self.is_user_marked_for_deletion(self.user_1))
         self.assertFalse(self.is_user_marked_for_deletion(self.user_3))


### PR DESCRIPTION
# Motivation and Context
The account created but not verified for 80 hrs will be picked by the scheduler and will be marked for deletion to be picked up by scheduler for hard delete

# What has changed
Additional logic has been added to the mark_for_deletion endpoint to check for accounts not activated for 80hrs

# How to test?
Smoke test 
# Links
[Trello](https://trello.com/c/Del0jv0g/15-s20-gdpr-retention-accounts-not-activated-should-be-deleted-after-80-hours-time-13)