### PR TITLE
Removing sql proxy container from notification scheduler

### DIFF
--- a/_infra/helm/auth/Chart.yaml
+++ b/_infra/helm/auth/Chart.yaml
@@ -19,4 +19,4 @@ version: 1.1.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.1.5
+appVersion: 2.1.6

--- a/_infra/helm/auth/templates/auth-due-deletion-notification-cron-task.yml
+++ b/_infra/helm/auth/templates/auth-due-deletion-notification-cron-task.yml
@@ -63,7 +63,7 @@ spec:
                 {{- else }}
                 value: "http://$(PARTY_SERVICE_HOST):$(PARTY_SERVICE_PORT)"
                 {{- end }}
-              - name: PARTY_URL
+              - name: AUTH_URL
                 {{- if .Values.dns.enabled }}
                 value: "http://auth.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.dns.wellKnownPort }}"
                 {{- else }}

--- a/_infra/helm/auth/templates/auth-due-deletion-notification-cron-task.yml
+++ b/_infra/helm/auth/templates/auth-due-deletion-notification-cron-task.yml
@@ -23,32 +23,6 @@ spec:
                   path: "credentials.json"
             {{- end }}
           containers:
-          {{- if .Values.database.sqlProxyEnabled }}
-          - name: cloudsql-proxy
-            image: gcr.io/cloudsql-docker/gce-proxy:1.16
-            command: ["/cloud_sql_proxy",
-                      "-instances=$(SQL_INSTANCE_NAME)=tcp:$(DB_PORT)",
-                      "-ip_address_types=PRIVATE",
-                      "-credential_file=/secrets/cloudsql/credentials.json"]
-            securityContext:
-              runAsUser: 2  # non-root user
-              allowPrivilegeEscalation: false
-            volumeMounts:
-              - name: cloudsql-instance-credentials
-                mountPath: /secrets/cloudsql
-                readOnly: true
-            env:
-            - name: SQL_INSTANCE_NAME
-              valueFrom:
-                configMapKeyRef:
-                  name: cloudsql-proxy-config
-                  key: instance-connection-name
-            - name: DB_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: db-config
-                  key: db-port
-          {{- end }}
           - name: {{ .Values.crons.dueDeletionNotificationScheduler.image }}
             {{- if eq .Values.image.tag "latest"}}
             image: "{{ .Values.image.name }}/{{ .Values.crons.dueDeletionNotificationScheduler.image }}:{{ .Chart.AppVersion }}"
@@ -59,35 +33,6 @@ spec:
               - name: google-cloud-key
                 mountPath: /var/secrets/google
             env:
-              - name: DB_HOST
-                {{- if .Values.database.managedPostgres }}
-                valueFrom:
-                  secretKeyRef:
-                    name: db-config
-                    key: db-host
-                {{- else }}
-                value: $(POSTGRES_SERVICE_HOST)
-                {{- end }}
-              - name: DB_PORT
-                valueFrom:
-                  secretKeyRef:
-                    name: db-config
-                    key: db-port
-              - name: DB_NAME
-                valueFrom:
-                  secretKeyRef:
-                    name: db-config
-                    key: {{ .Values.database.secrets.nameKey }}
-              - name: DB_USERNAME
-                valueFrom:
-                  secretKeyRef:
-                    name: db-credentials
-                    key: {{ .Values.database.secrets.usernameKey }}
-              - name: DB_PASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    name: db-credentials
-                    key: {{ .Values.database.secrets.passwordKey }}
               - name: SECURITY_USER_NAME
                 valueFrom:
                   secretKeyRef:
@@ -118,16 +63,16 @@ spec:
                 {{- else }}
                 value: "http://$(PARTY_SERVICE_HOST):$(PARTY_SERVICE_PORT)"
                 {{- end }}
+              - name: PARTY_URL
+                {{- if .Values.dns.enabled }}
+                value: "http://auth.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.dns.wellKnownPort }}"
+                {{- else }}
+                value: "http://$(AUTH_SERVICE_HOST):$(AUTH_SERVICE_PORT)"
+                {{- end }}
               - name: PORT
                 value: "{{ .Values.container.port }}"
               - name: APP_SETTINGS
                 value: "DevelopmentConfig"
-              - name: DATABASE_URI
-                {{- if .Values.database.sqlProxyEnabled }}
-                value: "postgresql://$(DB_USERNAME):$(DB_PASSWORD)@127.0.0.1:$(DB_PORT)/$(DB_NAME)"
-                {{- else }}
-                value: "postgresql://$(DB_USERNAME):$(DB_PASSWORD)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)"
-                {{- end }}
               - name: LOGGING_LEVEL
                 value: "DEBUG"
           restartPolicy: OnFailure

--- a/config.py
+++ b/config.py
@@ -12,7 +12,7 @@ class Config(object):
     SECURITY_USER_PASSWORD = os.getenv('SECURITY_USER_PASSWORD')
     DATABASE_URI = os.getenv('DATABASE_URI', "postgresql://postgres:postgres@localhost:5432/postgres")
     PARTY_URL = os.getenv('PARTY_URL')
-    AUTH_URL = os.getenv('AUTH_URL', 'http://localhost:8041')
+    AUTH_URL = os.getenv('AUTH_URL')
     BASIC_AUTH = (SECURITY_USER_NAME, SECURITY_USER_PASSWORD)
     DUE_DELETION_FIRST_NOTIFICATION_TEMPLATE = os.getenv('DUE_DELETION_FIRST_NOTIFICATION_TEMPLATE',
                                                          'due_deletion_first_notification_templates')

--- a/config.py
+++ b/config.py
@@ -8,8 +8,8 @@ class Config(object):
     DATABASE_SCHEMA = 'auth'
     PORT = os.getenv('PORT', 8041)
     LOGGING_LEVEL = os.getenv('LOGGING_LEVEL', 'INFO')
-    SECURITY_USER_NAME = os.getenv('SECURITY_USER_NAME', 'admin')
-    SECURITY_USER_PASSWORD = os.getenv('SECURITY_USER_PASSWORD', 'secret')
+    SECURITY_USER_NAME = os.getenv('SECURITY_USER_NAME')
+    SECURITY_USER_PASSWORD = os.getenv('SECURITY_USER_PASSWORD')
     DATABASE_URI = os.getenv('DATABASE_URI', "postgresql://postgres:postgres@localhost:5432/ras")
     PARTY_URL = os.getenv('PARTY_URL')
     AUTH_URL = os.getenv('AUTH_URL', 'http://localhost:8041')

--- a/config.py
+++ b/config.py
@@ -10,7 +10,7 @@ class Config(object):
     LOGGING_LEVEL = os.getenv('LOGGING_LEVEL', 'INFO')
     SECURITY_USER_NAME = os.getenv('SECURITY_USER_NAME')
     SECURITY_USER_PASSWORD = os.getenv('SECURITY_USER_PASSWORD')
-    DATABASE_URI = os.getenv('DATABASE_URI', "postgresql://postgres:postgres@localhost:5432/ras")
+    DATABASE_URI = os.getenv('DATABASE_URI', "postgresql://postgres:postgres@localhost:5432/postgres")
     PARTY_URL = os.getenv('PARTY_URL')
     AUTH_URL = os.getenv('AUTH_URL', 'http://localhost:8041')
     BASIC_AUTH = (SECURITY_USER_NAME, SECURITY_USER_PASSWORD)

--- a/config.py
+++ b/config.py
@@ -8,10 +8,11 @@ class Config(object):
     DATABASE_SCHEMA = 'auth'
     PORT = os.getenv('PORT', 8041)
     LOGGING_LEVEL = os.getenv('LOGGING_LEVEL', 'INFO')
-    SECURITY_USER_NAME = os.getenv('SECURITY_USER_NAME')
-    SECURITY_USER_PASSWORD = os.getenv('SECURITY_USER_PASSWORD')
-    DATABASE_URI = os.getenv('DATABASE_URI', "postgresql://postgres:postgres@localhost:5432/postgres")
+    SECURITY_USER_NAME = os.getenv('SECURITY_USER_NAME', 'admin')
+    SECURITY_USER_PASSWORD = os.getenv('SECURITY_USER_PASSWORD', 'secret')
+    DATABASE_URI = os.getenv('DATABASE_URI', "postgresql://postgres:postgres@localhost:5432/ras")
     PARTY_URL = os.getenv('PARTY_URL')
+    AUTH_URL = os.getenv('AUTH_URL', 'http://localhost:8041')
     BASIC_AUTH = (SECURITY_USER_NAME, SECURITY_USER_PASSWORD)
     DUE_DELETION_FIRST_NOTIFICATION_TEMPLATE = os.getenv('DUE_DELETION_FIRST_NOTIFICATION_TEMPLATE',
                                                          'due_deletion_first_notification_templates')
@@ -38,3 +39,4 @@ class TestingConfig(Config):
     SECURITY_USER_PASSWORD = 'secret'
     DATABASE_URI = os.getenv("TEST_DATABASE_URI", "postgresql://postgres:postgres@localhost:5432/postgres")
     BASIC_AUTH = (SECURITY_USER_NAME, SECURITY_USER_PASSWORD)
+    AUTH_URL = os.getenv('AUTH_URL', 'http://localhost:8041')

--- a/ras_rm_auth_scheduler_service/process_due_deletion_notification_job.py
+++ b/ras_rm_auth_scheduler_service/process_due_deletion_notification_job.py
@@ -1,38 +1,74 @@
+import base64
 from datetime import datetime
-from itertools import chain
 
-from ras_rm_auth_scheduler_service.db import setup
-from ras_rm_auth_scheduler_service.helper import get_query
+import requests
+
+import config as cfg
 from ras_rm_auth_scheduler_service.logger import logger
 from ras_rm_auth_scheduler_service.notify_service import NotifyService
+from ras_rm_auth_service.resources.tokens import obfuscate_email
 
 
-def _get_notification_column(template_name):
-    templates = {'first_notification': "first_notification",
-                 'second_notification': "second_notification",
-                 'third_notification': "third_notification"}
-    if template_name in templates:
-        return templates[template_name]
-    else:
-        raise KeyError('Notification column does not exist')
+class ProcessNotificationJob:
+    def __init__(self):
+        auth_url = cfg.Config.AUTH_URL
+        self.first_notification_url = f'{auth_url}/api/batch/account/users/eligible-for-first-notification'
+        self.second_notification_url = f'{auth_url}/api/batch/account/users/eligible-for-second-notification'
+        self.third_notification_url = f'{auth_url}/api/batch/account/users/eligible-for-third-notification'
+        self.patch_url = f'{auth_url}/api/account/user'
+        auth = "{}:{}".format(cfg.Config.SECURITY_USER_NAME, cfg.Config.SECURITY_USER_PASSWORD).encode('utf-8')
+        self.headers = {
+            'Authorization': 'Basic %s' % base64.b64encode(bytes(auth)).decode("ascii")
+        }
 
+    def process_first_notification(self):
+        users = self._get_eligible_users(self.first_notification_url)
+        if users:
+            self._process_notification(users, 'first_notification')
+        else:
+            logger.info("No user eligible for first notification")
 
-def process_notification_job(date_one, date_two, scheduler):
-    con = setup.get_connection()
-    csr = con.cursor()
-    column_name = _get_notification_column(scheduler)
-    query = get_query(date_one, date_two, column_name)
-    csr.execute(query)
-    users = [x for x in chain.from_iterable(csr.fetchall()) if isinstance(x, str)]
-    for username in users:
-        logger.info(f"Sending due deletion {scheduler} to user")
-        NotifyService().request_to_notify(template_name=scheduler,
-                                          email=username)
-        logger.info(f"Due deletion {scheduler} sent to user")
-        logger.info(f"updating {column_name} for user")
-        csr.execute(
-            f"Update auth.user set {column_name} = '{datetime.utcnow()}' where auth.user.username = '{username}'")
-        con.commit()
-        logger.info(f"updated {column_name} for user")
-    csr.close()
-    con.close()
+    def process_second_notification(self):
+        users = self._get_eligible_users(self.second_notification_url)
+        if users:
+            self._process_notification(users, 'second_notification')
+        else:
+            logger.info("No user eligible for second notification")
+
+    def process_third_notification(self):
+        users = self._get_eligible_users(self.third_notification_url)
+        if users:
+            self._process_notification(users, 'third_notification')
+        else:
+            logger.info("No user eligible for third notification")
+
+    def _process_notification(self, users, scheduler):
+        for username in users:
+            logger.info(f"Sending due deletion {scheduler} to user", username=obfuscate_email(username))
+            NotifyService().request_to_notify(template_name=scheduler,
+                                              email=username)
+            logger.info(f"Due deletion {scheduler} sent to user", username=obfuscate_email(username))
+            self._update_user(username, scheduler)
+
+    def _update_user(self, user, scheduler_column):
+        logger.info('Updating user data with notification sent date', notification=scheduler_column)
+        form_data = {scheduler_column: datetime.utcnow()}
+        try:
+            requests.patch(f'{self.patch_url}/{user}', data=form_data, headers=self.headers)
+        except requests.exceptions.HTTPError as error:
+            logger.exception(
+                "Unable to update user notification date", username=obfuscate_email(user),
+                error=error)
+            raise error
+        logger.info('user data with notification sent date updated', notification=scheduler_column)
+
+    def _get_eligible_users(self, url):
+
+        try:
+            response = requests.get(url, headers=self.headers)
+            return response.json()
+        except requests.exceptions.HTTPError as error:
+            logger.exception(
+                "Unable to communicate to auth service to fetch eligible users",
+                error=error)
+            raise error

--- a/ras_rm_auth_service/batch_process_endpoints.py
+++ b/ras_rm_auth_service/batch_process_endpoints.py
@@ -72,7 +72,7 @@ def get_users_eligible_for_first_notification():
                             if isinstance(x, str)])
     except NoResultFound:
         logger.info("No existing user eligible for first due deletion notification")
-        return {}, 400
+        return {}, 404
 
 
 @batch.route('users/eligible-for-second-notification', methods=['GET'])
@@ -96,7 +96,7 @@ def get_users_eligible_for_second_notification():
                             if isinstance(x, str)])
     except NoResultFound:
         logger.info("No existing user eligible for second due deletion notification")
-        return {}, 400
+        return {}, 404
 
 
 @batch.route('users/eligible-for-third-notification', methods=['GET'])
@@ -120,7 +120,7 @@ def get_users_eligible_for_third_notification():
                             if isinstance(x, str)])
     except NoResultFound:
         logger.info("No existing user eligible for third due deletion notification")
-        return {}, 400
+        return {}, 404
 
 
 @batch.route('users/mark-for-deletion', methods=['DELETE'])

--- a/ras_rm_auth_service/batch_process_endpoints.py
+++ b/ras_rm_auth_service/batch_process_endpoints.py
@@ -72,7 +72,7 @@ def get_users_eligible_for_first_notification():
                             if isinstance(x, str)])
     except NoResultFound:
         logger.info("No existing user eligible for first due deletion notification")
-        return '', 200
+        return {}, 400
 
 
 @batch.route('users/eligible-for-second-notification', methods=['GET'])
@@ -96,7 +96,7 @@ def get_users_eligible_for_second_notification():
                             if isinstance(x, str)])
     except NoResultFound:
         logger.info("No existing user eligible for second due deletion notification")
-        return '', 200
+        return {}, 400
 
 
 @batch.route('users/eligible-for-third-notification', methods=['GET'])
@@ -120,7 +120,7 @@ def get_users_eligible_for_third_notification():
                             if isinstance(x, str)])
     except NoResultFound:
         logger.info("No existing user eligible for third due deletion notification")
-        return '', 200
+        return {}, 400
 
 
 @batch.route('users/mark-for-deletion', methods=['DELETE'])

--- a/ras_rm_auth_service/models/models.py
+++ b/ras_rm_auth_service/models/models.py
@@ -113,6 +113,9 @@ class User(Base):
 
     def patch_user(self, patch_params):
         self.mark_for_deletion = patch_params.get('mark_for_deletion', self.mark_for_deletion)
+        self.first_notification = patch_params.get('first_notification', self.first_notification)
+        self.second_notification = patch_params.get('second_notification', self.second_notification)
+        self.third_notification = patch_params.get('third_notification', self.third_notification)
 
 
 class AccountSchema(Schema):
@@ -125,4 +128,7 @@ class AccountSchema(Schema):
 class PatchAccountSchema(Schema):
     """ Account data which is required for the operation patch
     """
-    mark_for_deletion = fields.Boolean(required=True)
+    mark_for_deletion = fields.Boolean(required=False)
+    first_notification = fields.DateTime(required=False)
+    second_notification = fields.DateTime(required=False)
+    third_notification = fields.DateTime(required=False)

--- a/ras_rm_auth_service/resources/account.py
+++ b/ras_rm_auth_service/resources/account.py
@@ -110,7 +110,8 @@ def get_account_by_user_name(username):
 def patch_account(username):
     """
     Patch endpoint for user resource.
-    Currently only marked_for_deletion attribute can be patched
+    Currently only marked_for_deletion, first_notification, second_notification and third_notification
+     attribute can be patched
     @param: username
     """
     logger.info("Starting patch operation on user", username=obfuscate_email(username))

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,20 +1,14 @@
 
 from ras_rm_auth_scheduler_service.logger import logger
-from ras_rm_auth_scheduler_service.process_due_deletion_notification_job import process_notification_job
-from datetime import timedelta, datetime
-
+from ras_rm_auth_scheduler_service.process_due_deletion_notification_job import ProcessNotificationJob
 
 if __name__ == '__main__':
-    _datetime_24_months_ago = datetime.utcnow() - timedelta(days=730)
-    _datetime_30_months_ago = datetime.utcnow() - timedelta(days=913)
-    _datetime_35_months_ago = datetime.utcnow() - timedelta(days=1065)
-    _datetime_36_months_ago = datetime.utcnow() - timedelta(days=1095)
     logger.info("Scheduler processing Accounts not accessed in the last 35 months ")
-    process_notification_job(_datetime_36_months_ago, _datetime_35_months_ago, 'third_notification')
+    ProcessNotificationJob().process_third_notification()
     logger.info("Scheduler finished processing Accounts not accessed in last 35 months")
     logger.info("Scheduler processing Accounts not accessed in the last 30 months ")
-    process_notification_job(_datetime_35_months_ago, _datetime_30_months_ago, 'second_notification')
+    ProcessNotificationJob().process_second_notification()
     logger.info("Scheduler finished processing Accounts not accessed in last 30 months")
     logger.info("Scheduler processing Accounts not accessed in the last 24 months ")
-    process_notification_job(_datetime_30_months_ago, _datetime_24_months_ago, 'first_notification')
+    ProcessNotificationJob().process_first_notification()
     logger.info("Scheduler finished processing Accounts not accessed in last 24 months")

--- a/test/resources/test_account.py
+++ b/test/resources/test_account.py
@@ -1,5 +1,6 @@
 import base64
 import unittest
+from datetime import datetime
 from unittest.mock import patch
 
 from sqlalchemy.exc import SQLAlchemyError
@@ -433,3 +434,63 @@ class TestAccount(unittest.TestCase):
         self.assertEqual(response.status_code, 500)
         self.assertEqual(response.get_json(), {"title": "Auth service undo delete user error",
                                                "detail": "Unable to commit undo delete operation"})
+
+    def test_patch_user_account_first_notification(self):
+        """
+        Test update first_notification
+        """
+        time = datetime.utcnow()
+        # Given
+        form_data = {"username": "testuser@email.com", "password": "password"}
+        self.client.post('/api/account/create', data=form_data, headers=self.headers)
+        # When
+        response = self.client.get('/api/account/user/testuser@email.com',
+                                   headers=self.headers)
+        self.assertEqual(response.get_json()['first_notification'], None)
+        form_data_new = {"first_notification": time}
+        # Then
+        upsert = self.client.patch('/api/account/user/testuser@email.com', data=form_data_new, headers=self.headers)
+        self.assertEqual(upsert.status_code, 204)
+        new_response = self.client.get('/api/account/user/testuser@email.com',
+                                       headers=self.headers)
+        self.assertIsNot(None, new_response.get_json()['first_notification'])
+
+    def test_patch_user_account_second_notification(self):
+        """
+        Test update first_notification
+        """
+        time = datetime.utcnow()
+        # Given
+        form_data = {"username": "testuser@email.com", "password": "password"}
+        self.client.post('/api/account/create', data=form_data, headers=self.headers)
+        # When
+        response = self.client.get('/api/account/user/testuser@email.com',
+                                   headers=self.headers)
+        self.assertEqual(response.get_json()['first_notification'], None)
+        form_data_new = {"second_notification": time}
+        # Then
+        upsert = self.client.patch('/api/account/user/testuser@email.com', data=form_data_new, headers=self.headers)
+        self.assertEqual(upsert.status_code, 204)
+        new_response = self.client.get('/api/account/user/testuser@email.com',
+                                       headers=self.headers)
+        self.assertIsNot(None, new_response.get_json()['second_notification'])
+
+    def test_patch_user_account_third_notification(self):
+        """
+        Test update first_notification
+        """
+        time = datetime.utcnow()
+        # Given
+        form_data = {"username": "testuser@email.com", "password": "password"}
+        self.client.post('/api/account/create', data=form_data, headers=self.headers)
+        # When
+        response = self.client.get('/api/account/user/testuser@email.com',
+                                   headers=self.headers)
+        self.assertEqual(response.get_json()['first_notification'], None)
+        form_data_new = {"third_notification": time}
+        # Then
+        upsert = self.client.patch('/api/account/user/testuser@email.com', data=form_data_new, headers=self.headers)
+        self.assertEqual(upsert.status_code, 204)
+        new_response = self.client.get('/api/account/user/testuser@email.com',
+                                       headers=self.headers)
+        self.assertIsNot(None, new_response.get_json()['third_notification'])

--- a/test/scheduler_service/test_process_due_deletion_notification_job.py
+++ b/test/scheduler_service/test_process_due_deletion_notification_job.py
@@ -1,258 +1,147 @@
 import unittest
+from collections import namedtuple
 from unittest.mock import patch, Mock
-from datetime import timedelta, datetime
 
-from ras_rm_auth_scheduler_service.helper import AuthDueDeletionSchedulerError
-from ras_rm_auth_scheduler_service.notify_service import NotifyError
-from ras_rm_auth_scheduler_service.process_due_deletion_notification_job import process_notification_job
+import requests
 
+from ras_rm_auth_scheduler_service.process_due_deletion_notification_job import ProcessNotificationJob
 
-def process_due_deletion_notification_job():
-    pass
+fake_response = namedtuple('Response', 'status_code json')
 
 
 class TestNotificationJob(unittest.TestCase):
-    _datetime_24_months_ago = datetime.utcnow() - timedelta(days=730)
-    _datetime_30_months_ago = datetime.utcnow() - timedelta(days=913)
-    _datetime_35_months_ago = datetime.utcnow() - timedelta(days=1065)
-    _datetime_36_months_ago = datetime.utcnow() - timedelta(days=1095)
 
     def test_successful_first_notification(self):
-        with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.setup')as setup:
-            with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService'
-                       '.request_to_notify'
-                       )as mock_notify:
-                mock_notify.return_value = Mock()
-                to_test = [('test@test.com',), ('test1test.com',), ('test2@test.com',)]
-                mock_cursor = Mock()
-                cursor_attrs = {'fetchall.return_value': to_test}
-                mock_cursor.configure_mock(**cursor_attrs)
-                mock_con = Mock()
-                engine_attrs = {'cursor.return_value': mock_cursor}
-                mock_con.configure_mock(**engine_attrs)
-                setup.get_connection.return_value = mock_con
-                process_notification_job(self._datetime_30_months_ago,
-                                         self._datetime_24_months_ago,
-                                         'first_notification')
-                self.assertEqual(mock_notify.call_count, 3)
-                self.assertEqual(mock_con.commit.call_count, 3)
+        with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.get') as mock_get:
+            with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.patch') \
+                                                                                                as mock_patch:
+                with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService'
+                           '.request_to_notify'
+                           )as mock_notify:
+                    mock_notify.return_value = Mock()
+                    mock_get.return_value = fake_response(status_code=200, json=lambda: ['dummy@email.com',
+                                                                                         'dummy1@email.com',
+                                                                                         'dummy2@email.com'])
+                    mock_patch.return_value = fake_response(status_code=204, json=lambda: [])
+                    ProcessNotificationJob().process_first_notification()
+                    self.assertEqual(mock_notify.call_count, 3)
+                    self.assertEqual(mock_get.call_count, 1)
+                    self.assertEqual(mock_patch.call_count, 3)
 
     def test_no_notification_required_for_first_notification(self):
-        with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.setup')as setup:
-            with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService'
-                       '.request_to_notify'
-                       )as mock_notify:
-                mock_notify.return_value = Mock()
-                to_test = []
-                mock_cursor = Mock()
-                cursor_attrs = {'fetchall.return_value': to_test}
-                mock_cursor.configure_mock(**cursor_attrs)
-                mock_con = Mock()
-                engine_attrs = {'cursor.return_value': mock_cursor}
-                mock_con.configure_mock(**engine_attrs)
-                setup.get_connection.return_value = mock_con
-                process_notification_job(self._datetime_30_months_ago,
-                                         self._datetime_24_months_ago,
-                                         'first_notification')
-                self.assertEqual(mock_notify.call_count, 0)
-                self.assertEqual(mock_con.commit.call_count, 0)
+        with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.get') as mock_get:
+            with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.patch') \
+                                                                                                as mock_patch:
+                with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService'
+                           '.request_to_notify'
+                           )as mock_notify:
+                    mock_notify.return_value = Mock()
+                    mock_get.return_value = fake_response(status_code=200, json=lambda: [])
+                    mock_patch.return_value = fake_response(status_code=204, json=lambda: [])
+                    ProcessNotificationJob().process_first_notification()
+                    self.assertEqual(mock_notify.call_count, 0)
+                    self.assertEqual(mock_get.call_count, 1)
+                    self.assertEqual(mock_patch.call_count, 0)
 
     def test_no_connection_for_first_notification(self):
-        with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.setup')as setup:
-            with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService'
-                       '.request_to_notify'
-                       )as mock_notify:
-                mock_notify.return_value = Mock()
-                to_test = []
-                mock_cursor = Mock()
-                cursor_attrs = {'fetchall.return_value': to_test}
-                mock_cursor.configure_mock(**cursor_attrs)
-                mock_con = Mock()
-                engine_attrs = {'cursor.return_value': mock_cursor}
-                mock_con.configure_mock(**engine_attrs)
-                setup.get_connection.side_effect = AuthDueDeletionSchedulerError('Unable to establish database '
-                                                                                 'connection.')
-                with self.assertRaises(AuthDueDeletionSchedulerError):
-                    process_notification_job(self._datetime_30_months_ago,
-                                             self._datetime_24_months_ago,
-                                             'first_notification')
-
-    def test_notification_error_for_first_notification(self):
-        with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.setup')as setup:
-            with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService'
-                       '.request_to_notify'
-                       )as mock_notify:
-                mock_notify.side_effect = NotifyError()
-                to_test = [('test@test.com',), ('test1test.com',), ('test2@test.com',)]
-                mock_cursor = Mock()
-                cursor_attrs = {'fetchall.return_value': to_test}
-                mock_cursor.configure_mock(**cursor_attrs)
-                mock_con = Mock()
-                engine_attrs = {'cursor.return_value': mock_cursor}
-                mock_con.configure_mock(**engine_attrs)
-                setup.get_connection.return_value = mock_con
-                with self.assertRaises(NotifyError):
-                    process_notification_job(self._datetime_30_months_ago,
-                                             self._datetime_24_months_ago,
-                                             'first_notification')
-                    self.assertEqual(mock_con.commit.call_count, 0)
+        with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.get') as mock_get:
+            with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.patch') \
+                                                                                                as mock_patch:
+                with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService'
+                           '.request_to_notify'
+                           )as mock_notify:
+                    mock_notify.return_value = Mock()
+                    mock_get.side_effect = requests.exceptions.HTTPError("error")
+                    mock_patch.side_effect = requests.exceptions.HTTPError("error")
+                with self.assertRaises(requests.exceptions.HTTPError):
+                    ProcessNotificationJob().process_first_notification()
 
     def test_successful_second_notification(self):
-        with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.setup')as setup:
-            with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService'
-                       '.request_to_notify'
-                       )as mock_notify:
-                mock_notify.return_value = Mock()
-                to_test = [('test@test.com',), ('test1test.com',), ('test2@test.com',)]
-                mock_cursor = Mock()
-                cursor_attrs = {'fetchall.return_value': to_test}
-                mock_cursor.configure_mock(**cursor_attrs)
-                mock_con = Mock()
-                engine_attrs = {'cursor.return_value': mock_cursor}
-                mock_con.configure_mock(**engine_attrs)
-                setup.get_connection.return_value = mock_con
-                process_notification_job(self._datetime_30_months_ago,
-                                         self._datetime_24_months_ago,
-                                         'second_notification')
-                self.assertEqual(mock_notify.call_count, 3)
-                self.assertEqual(mock_con.commit.call_count, 3)
+        with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.get') as mock_get:
+            with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.patch') \
+                                                                                                as mock_patch:
+                with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService'
+                           '.request_to_notify'
+                           )as mock_notify:
+                    mock_notify.return_value = Mock()
+                    mock_get.return_value = fake_response(status_code=200, json=lambda: ['dummy@email.com',
+                                                                                         'dummy1@email.com',
+                                                                                         'dummy2@email.com'])
+                    mock_patch.return_value = fake_response(status_code=204, json=lambda: [])
+                    ProcessNotificationJob().process_second_notification()
+                    self.assertEqual(mock_notify.call_count, 3)
+                    self.assertEqual(mock_get.call_count, 1)
+                    self.assertEqual(mock_patch.call_count, 3)
 
     def test_no_notification_required_for_second_notification(self):
-        with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.setup')as setup:
-            with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService'
-                       '.request_to_notify'
-                       )as mock_notify:
-                mock_notify.return_value = Mock()
-                to_test = []
-                mock_cursor = Mock()
-                cursor_attrs = {'fetchall.return_value': to_test}
-                mock_cursor.configure_mock(**cursor_attrs)
-                mock_con = Mock()
-                engine_attrs = {'cursor.return_value': mock_cursor}
-                mock_con.configure_mock(**engine_attrs)
-                setup.get_connection.return_value = mock_con
-                process_notification_job(self._datetime_30_months_ago,
-                                         self._datetime_24_months_ago,
-                                         'second_notification')
-                self.assertEqual(mock_notify.call_count, 0)
-                self.assertEqual(mock_con.commit.call_count, 0)
+        with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.get') as mock_get:
+            with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.patch') \
+                                                                                                as mock_patch:
+                with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService'
+                           '.request_to_notify'
+                           )as mock_notify:
+                    mock_notify.return_value = Mock()
+                    mock_get.return_value = fake_response(status_code=200, json=lambda: [])
+                    mock_patch.return_value = fake_response(status_code=204, json=lambda: [])
+                    ProcessNotificationJob().process_second_notification()
+                    self.assertEqual(mock_notify.call_count, 0)
+                    self.assertEqual(mock_get.call_count, 1)
+                    self.assertEqual(mock_patch.call_count, 0)
 
     def test_no_connection_for_second_notification(self):
-        with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.setup')as setup:
-            with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService'
-                       '.request_to_notify'
-                       )as mock_notify:
-                mock_notify.return_value = Mock()
-                to_test = []
-                mock_cursor = Mock()
-                cursor_attrs = {'fetchall.return_value': to_test}
-                mock_cursor.configure_mock(**cursor_attrs)
-                mock_con = Mock()
-                engine_attrs = {'cursor.return_value': mock_cursor}
-                mock_con.configure_mock(**engine_attrs)
-                setup.get_connection.side_effect = AuthDueDeletionSchedulerError('Unable to establish database '
-                                                                                 'connection.')
-                with self.assertRaises(AuthDueDeletionSchedulerError):
-                    process_notification_job(self._datetime_30_months_ago,
-                                             self._datetime_24_months_ago,
-                                             'second_notification')
-
-    def test_notification_error_for_second_notification(self):
-        with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.setup')as setup:
-            with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService'
-                       '.request_to_notify'
-                       )as mock_notify:
-                mock_notify.side_effect = NotifyError()
-                to_test = [('test@test.com',), ('test1test.com',), ('test2@test.com',)]
-                mock_cursor = Mock()
-                cursor_attrs = {'fetchall.return_value': to_test}
-                mock_cursor.configure_mock(**cursor_attrs)
-                mock_con = Mock()
-                engine_attrs = {'cursor.return_value': mock_cursor}
-                mock_con.configure_mock(**engine_attrs)
-                setup.get_connection.return_value = mock_con
-                with self.assertRaises(NotifyError):
-                    process_notification_job(self._datetime_30_months_ago,
-                                             self._datetime_24_months_ago,
-                                             'second_notification')
-                    self.assertEqual(mock_con.commit.call_count, 0)
+        with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.get') as mock_get:
+            with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.patch') \
+                                                                                                as mock_patch:
+                with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService'
+                           '.request_to_notify'
+                           )as mock_notify:
+                    mock_notify.return_value = Mock()
+                    mock_get.side_effect = requests.exceptions.HTTPError("error")
+                    mock_patch.side_effect = requests.exceptions.HTTPError("error")
+                with self.assertRaises(requests.exceptions.HTTPError):
+                    ProcessNotificationJob().process_second_notification()
 
     def test_successful_third_notification(self):
-        with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.setup')as setup:
-            with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService'
-                       '.request_to_notify'
-                       )as mock_notify:
-                mock_notify.return_value = Mock()
-                to_test = [('test@test.com',), ('test1test.com',), ('test2@test.com',)]
-                mock_cursor = Mock()
-                cursor_attrs = {'fetchall.return_value': to_test}
-                mock_cursor.configure_mock(**cursor_attrs)
-                mock_con = Mock()
-                engine_attrs = {'cursor.return_value': mock_cursor}
-                mock_con.configure_mock(**engine_attrs)
-                setup.get_connection.return_value = mock_con
-                process_notification_job(self._datetime_30_months_ago,
-                                         self._datetime_24_months_ago,
-                                         'third_notification')
-                self.assertEqual(mock_notify.call_count, 3)
-                self.assertEqual(mock_con.commit.call_count, 3)
+        with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.get') as mock_get:
+            with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.patch') \
+                                                                                                as mock_patch:
+                with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService'
+                           '.request_to_notify'
+                           )as mock_notify:
+                    mock_notify.return_value = Mock()
+                    mock_get.return_value = fake_response(status_code=200, json=lambda: ['dummy@email.com',
+                                                                                         'dummy1@email.com',
+                                                                                         'dummy2@email.com'])
+                    mock_patch.return_value = fake_response(status_code=204, json=lambda: [])
+                    ProcessNotificationJob().process_third_notification()
+                    self.assertEqual(mock_notify.call_count, 3)
+                    self.assertEqual(mock_get.call_count, 1)
+                    self.assertEqual(mock_patch.call_count, 3)
 
     def test_no_notification_required_for_third_notification(self):
-        with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.setup')as setup:
-            with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService'
-                       '.request_to_notify'
-                       )as mock_notify:
-                mock_notify.return_value = Mock()
-                to_test = []
-                mock_cursor = Mock()
-                cursor_attrs = {'fetchall.return_value': to_test}
-                mock_cursor.configure_mock(**cursor_attrs)
-                mock_con = Mock()
-                engine_attrs = {'cursor.return_value': mock_cursor}
-                mock_con.configure_mock(**engine_attrs)
-                setup.get_connection.return_value = mock_con
-                process_notification_job(self._datetime_30_months_ago,
-                                         self._datetime_24_months_ago,
-                                         'third_notification')
-                self.assertEqual(mock_notify.call_count, 0)
-                self.assertEqual(mock_con.commit.call_count, 0)
+        with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.get') as mock_get:
+            with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.patch') \
+                                                                                                as mock_patch:
+                with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService'
+                           '.request_to_notify'
+                           )as mock_notify:
+                    mock_notify.return_value = Mock()
+                    mock_get.return_value = fake_response(status_code=200, json=lambda: [])
+                    mock_patch.return_value = fake_response(status_code=204, json=lambda: [])
+                    ProcessNotificationJob().process_third_notification()
+                    self.assertEqual(mock_notify.call_count, 0)
+                    self.assertEqual(mock_get.call_count, 1)
+                    self.assertEqual(mock_patch.call_count, 0)
 
     def test_no_connection_for_third_notification(self):
-        with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.setup')as setup:
-            with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService'
-                       '.request_to_notify'
-                       )as mock_notify:
-                mock_notify.return_value = Mock()
-                to_test = []
-                mock_cursor = Mock()
-                cursor_attrs = {'fetchall.return_value': to_test}
-                mock_cursor.configure_mock(**cursor_attrs)
-                mock_con = Mock()
-                engine_attrs = {'cursor.return_value': mock_cursor}
-                mock_con.configure_mock(**engine_attrs)
-                setup.get_connection.side_effect = AuthDueDeletionSchedulerError('Unable to establish database '
-                                                                                 'connection.')
-                with self.assertRaises(AuthDueDeletionSchedulerError):
-                    process_notification_job(self._datetime_30_months_ago,
-                                             self._datetime_24_months_ago,
-                                             'third_notification')
-
-    def test_notification_error_for_third_notification(self):
-        with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.setup')as setup:
-            with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService'
-                       '.request_to_notify'
-                       )as mock_notify:
-                mock_notify.side_effect = NotifyError()
-                to_test = [('test@test.com',), ('test1test.com',), ('test2@test.com',)]
-                mock_cursor = Mock()
-                cursor_attrs = {'fetchall.return_value': to_test}
-                mock_cursor.configure_mock(**cursor_attrs)
-                mock_con = Mock()
-                engine_attrs = {'cursor.return_value': mock_cursor}
-                mock_con.configure_mock(**engine_attrs)
-                setup.get_connection.return_value = mock_con
-                with self.assertRaises(NotifyError):
-                    process_notification_job(self._datetime_30_months_ago,
-                                             self._datetime_24_months_ago,
-                                             'third_notification')
-                    self.assertEqual(mock_con.commit.call_count, 0)
+        with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.get') as mock_get:
+            with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.patch') \
+                                                                                                as mock_patch:
+                with patch('ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService'
+                           '.request_to_notify'
+                           )as mock_notify:
+                    mock_notify.return_value = Mock()
+                    mock_get.side_effect = requests.exceptions.HTTPError("error")
+                    mock_patch.side_effect = requests.exceptions.HTTPError("error")
+                with self.assertRaises(requests.exceptions.HTTPError):
+                    ProcessNotificationJob().process_third_notification()


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The sql proxy container for notification scheduler keeps running.

# What has changed
sql interaction from the scheduler has been removed and endpoints has been provided for the same.

# How to test?
Smoke test

# Links
[Trello](https://trello.com/c/cph1QMSk/170-s22-bug-auth-due-deletion-notification-scheduler-job-implementation-update)
