### PR TITLE
Bug service not deleting

### DIFF
--- a/_infra/helm/auth/Chart.yaml
+++ b/_infra/helm/auth/Chart.yaml
@@ -19,4 +19,4 @@ version: 1.1.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.1.14
+appVersion: 2.1.15

--- a/ras_rm_auth_service/batch_process_endpoints.py
+++ b/ras_rm_auth_service/batch_process_endpoints.py
@@ -1,6 +1,5 @@
 import logging
 import base64
-import json
 from itertools import chain
 
 import requests

--- a/ras_rm_auth_service/batch_process_endpoints.py
+++ b/ras_rm_auth_service/batch_process_endpoints.py
@@ -182,7 +182,7 @@ def delete_party_respondents_and_auth_user(users, session):
 
     for user in users:
         try:
-            response = requests.post(url, auth=app.config['BASIC_AUTH'], data={'email': user.username})
+            response = requests.delete(url, auth=app.config['BASIC_AUTH'], data={'email': user.username})
             response.raise_for_status()
             logger.info('Successfully sent request to party service for user deletion',
                         status_code=response.status_code,

--- a/ras_rm_auth_service/batch_process_endpoints.py
+++ b/ras_rm_auth_service/batch_process_endpoints.py
@@ -38,8 +38,7 @@ def delete_accounts():
             marked_for_deletion_users = session.query(User).filter(User.mark_for_deletion == True)  # noqa
             if marked_for_deletion_users.count() > 0:
                 logger.info("sending request to party service to remove ")
-                delete_party_respondents(marked_for_deletion_users)
-                marked_for_deletion_users.delete()
+                delete_party_respondents_and_auth_user(marked_for_deletion_users, session)
                 logger.info("Scheduler successfully deleted users marked for deletion")
             else:
                 logger.info("No user marked for deletion at this time. Nothing to delete.")
@@ -179,21 +178,22 @@ def create_request(method, path, body, headers):
             "headers": headers}
 
 
-def delete_party_respondents(users):
-    batch_url = f'{app.config["PARTY_URL"]}/party-api/v1/batch/requests'
-    payload = []
+def delete_party_respondents_and_auth_user(users, session):
+    url = f'{app.config["PARTY_URL"]}/party-api/v1/respondents/email'
+
     for user in users:
-        payload.append(
-            create_request("DELETE", "/party-api/v1/respondents/email", {'email': user.username},
-                           auth_headers()), )
-
-    try:
-        response = requests.post(batch_url, auth=app.config['BASIC_AUTH'], data=json.dumps(payload))
-        response.raise_for_status()
-    except requests.exceptions.HTTPError as error:
-        logger.exception("Unable to send request to party service for user deletion. Can't proceed with user deletion.",
-                         error=error)
-        raise error
-
-    logger.info('Successfully sent request to party service for user deletion', status_code=response.status_code,
-                response_json=response.json())
+        try:
+            response = requests.post(url, auth=app.config['BASIC_AUTH'], data={'email': user.username})
+            response.raise_for_status()
+            logger.info('Successfully sent request to party service for user deletion',
+                        status_code=response.status_code,
+                        response_json=response.json())
+            session.delete(user)
+            logger.info('Successfully deleted user account')
+        except requests.exceptions.HTTPError as error:
+            if error.response.status_code == 404:
+                logger.warn('Respondent does not exists in party service')
+                session.delete(user)
+            else:
+                logger.exception("Unable to send request to party service for user deletion. Can't proceed with user "
+                                 "deletion.", error=error)

--- a/test/test_batch_process_endpoints.py
+++ b/test/test_batch_process_endpoints.py
@@ -4,8 +4,6 @@ from datetime import datetime, timedelta
 from unittest.mock import patch, MagicMock, PropertyMock
 
 import requests
-from requests.cookies import MockResponse
-from werkzeug.exceptions import NotFound
 
 from ras_rm_auth_service.models import models
 from sqlalchemy.exc import SQLAlchemyError

--- a/test/test_batch_process_endpoints.py
+++ b/test/test_batch_process_endpoints.py
@@ -128,7 +128,7 @@ class TestBatchProcessEndpoints(unittest.TestCase):
         self.assertTrue(self.is_user_marked_for_deletion(self.user_1))
         self.assertTrue(self.is_user_marked_for_deletion(self.user_3))
         self.assertFalse(self.is_user_marked_for_deletion(self.user_2))
-        with patch('ras_rm_auth_service.batch_process_endpoints.requests.post') as mock_request:
+        with patch('ras_rm_auth_service.batch_process_endpoints.requests.delete') as mock_request:
             mock_request.return_value = mock_response()
             batch_delete_request = self.client.delete('/api/batch/account/users', headers=self.headers)
             self.assertTrue(mock_request.called)
@@ -170,7 +170,7 @@ class TestBatchProcessEndpoints(unittest.TestCase):
         self.assertTrue(self.is_user_marked_for_deletion(self.user_1))
         self.assertTrue(self.is_user_marked_for_deletion(self.user_3))
         self.assertFalse(self.is_user_marked_for_deletion(self.user_2))
-        with patch('ras_rm_auth_service.batch_process_endpoints.requests.post') as mock_request:
+        with patch('ras_rm_auth_service.batch_process_endpoints.requests.delete') as mock_request:
             mock_resp = requests.models.Response()
             mock_resp.status_code = 500
             mock_request.return_value = mock_resp
@@ -214,7 +214,7 @@ class TestBatchProcessEndpoints(unittest.TestCase):
         self.assertTrue(self.is_user_marked_for_deletion(self.user_1))
         self.assertTrue(self.is_user_marked_for_deletion(self.user_3))
         self.assertFalse(self.is_user_marked_for_deletion(self.user_2))
-        with patch('ras_rm_auth_service.batch_process_endpoints.requests.post') as mock_request:
+        with patch('ras_rm_auth_service.batch_process_endpoints.requests.delete') as mock_request:
             mock_resp = requests.models.Response()
             mock_resp.status_code = 404
             mock_request.return_value = mock_resp


### PR DESCRIPTION
# Motivation and Context
BUG: Auth service not deleting marked accounts when no Party entry exists.

# What has changed
logic added to ignore 404s

# How to test?
smoke test

# Links
[Trello](https://trello.com/c/CFgASG3U/426-bug-auth-service-not-deleting-marked-accounts-when-no-party-entry-exists)