### PR TITLE
Stop using developer config in prod

### DIFF
--- a/_infra/helm/auth/Chart.yaml
+++ b/_infra/helm/auth/Chart.yaml
@@ -19,4 +19,4 @@ version: 1.1.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.1.16
+appVersion: 2.1.17

--- a/_infra/helm/auth/templates/deployment.yaml
+++ b/_infra/helm/auth/templates/deployment.yaml
@@ -135,7 +135,11 @@ spec:
           - name: PORT
             value: "{{ .Values.container.port }}"
           - name: APP_SETTINGS
+            {{- if .Values.developmentConfig }}
             value: "DevelopmentConfig"
+            {{- else }}
+            value: "Config"
+            {{- end }}
           - name: DATABASE_URI
             {{- if .Values.database.sqlProxyEnabled }}
             value: "postgresql://$(DB_USERNAME):$(DB_PASSWORD)@127.0.0.1:$(DB_PORT)/$(DB_NAME)"

--- a/_infra/helm/auth/values.yaml
+++ b/_infra/helm/auth/values.yaml
@@ -74,3 +74,5 @@ sendEmailToGovNotify: true
 gcp:
   project: ras-rm-sandbox
   topic: ras-rm-notify-test
+
+developmentConfig: true


### PR DESCRIPTION
# Motivation and Context
The requests library is logging every single call it makes because we're set at `DEBUG` due to being in DevelopmentConfig in all environments, including preprod and prod. This would be vaguely okay except we sometimes need to make calls to URLs that have personally identifiable info in them, which is bad.