### PR TITLE
Docker tag latest at the same time as the release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,13 +151,15 @@ jobs:
       - name: Build Release Image
         if: github.ref == 'refs/heads/main'
         run: |
-          docker build -f _infra/docker/Dockerfile -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ steps.release.outputs.version }} .
-          docker build -f _infra/docker/scheduler.Dockerfile -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$SCHEDULER_IMAGE":${{ steps.release.outputs.version }} .
+          docker build -f _infra/docker/Dockerfile -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":latest -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ steps.release.outputs.version }} .
+          docker build -f _infra/docker/scheduler.Dockerfile -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$SCHEDULER_IMAGE":latest -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$SCHEDULER_IMAGE":${{ steps.release.outputs.version }} .
       - name: Push Release image
         if: github.ref == 'refs/heads/main'
         run: |
           docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ steps.release.outputs.version }}
+          docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":latest
           docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$SCHEDULER_IMAGE":${{ steps.release.outputs.version }}
+          docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$SCHEDULER_IMAGE":latest
       - name: Publish Charts
         if: github.ref == 'refs/heads/main'
         run: |

--- a/_infra/helm/auth/Chart.yaml
+++ b/_infra/helm/auth/Chart.yaml
@@ -19,5 +19,5 @@ version: 1.1.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.1.25
+appVersion: 2.1.26
 


### PR DESCRIPTION
# What and why?
During the release step tag the generated docker image as both the release version and latest.
# How to test?

# Trello
