### PR TITLE
first pass at fixing email obfuscation issue

### DIFF
--- a/_infra/helm/auth/Chart.yaml
+++ b/_infra/helm/auth/Chart.yaml
@@ -14,10 +14,10 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.1.35
+version: 2.1.36
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.1.35
+appVersion: 2.1.36
 

--- a/ras_rm_auth_service/resources/tokens.py
+++ b/ras_rm_auth_service/resources/tokens.py
@@ -77,7 +77,17 @@ def obfuscate_email(email):
     """Takes an email address and returns an obfuscated version of it.
     For example: test@example.com would turn into t**t@e*********m
     """
-    m = email.split("@")
-    prefix = f'{m[0][0]}{"*"*(len(m[0])-2)}{m[0][-1]}'
-    domain = f'{m[1][0]}{"*"*(len(m[1])-2)}{m[1][-1]}'
-    return f"{prefix}@{domain}"
+    if email is None:
+        return None
+    splitmail = email.split("@")
+    # If the prefix is 1 character, then we can't obfuscate it
+    if len(splitmail[0]) <= 1:
+        prefix = splitmail[0]
+    else:
+        prefix = f'{splitmail[0][0]}{"*"*(len(splitmail[0])-2)}{splitmail[0][-1]}'
+    # If the domain is missing or 1 character, then we can't obfuscate it
+    if len(splitmail) <= 1 or len(splitmail[1]) <= 1:
+        return f"{prefix}"
+    else:
+        domain = f'{splitmail[1][0]}{"*"*(len(splitmail[1])-2)}{splitmail[1][-1]}'
+        return f"{prefix}@{domain}"

--- a/test/resources/test_tokens.py
+++ b/test/resources/test_tokens.py
@@ -276,7 +276,7 @@ class TestTokens(unittest.TestCase):
             ["a.b.c.someone@example.com", "a***********e@e*********m"],
             ["john.smith123456@londinium.ac.co.uk", "j**************6@l****************k"],
             ["me!?@example.com", "m**?@e*********m"],
-            # ["m@m.com", "m@m***m"],
+            ["m@m.com", "m@m***m"],
         ]
 
         for scenario in test_scenarios:


### PR DESCRIPTION
# What and why?
The obfuscate_email function in this repo couldn't handle single-character e-mail prefixes, but the equivalent function in ras-party could. The code from ras-party has been copied over to here, and a failing test case uncommented.

# Trello
[Card](https://trello.com/c/fYuMdTuQ)
