### PR TITLE
RAS-720 update Cronjob to v1

### DIFF
--- a/_infra/helm/auth/Chart.yaml
+++ b/_infra/helm/auth/Chart.yaml
@@ -14,10 +14,10 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.1.44
+version: 2.1.45
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.1.44
+appVersion: 2.1.45
 

--- a/_infra/helm/auth/Chart.yaml
+++ b/_infra/helm/auth/Chart.yaml
@@ -14,10 +14,10 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.1.43
+version: 2.1.44
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 2.1.43
+appVersion: 2.1.44
 

--- a/_infra/helm/auth/templates/auth-due-deletion-notification-cron-task.yml
+++ b/_infra/helm/auth/templates/auth-due-deletion-notification-cron-task.yml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Values.crons.dueDeletionNotificationScheduler.name }}

--- a/_infra/helm/auth/templates/auth-user-deletion-cron-task.yml
+++ b/_infra/helm/auth/templates/auth-user-deletion-cron-task.yml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Values.crons.deleteUsersScheduler.name }}

--- a/_infra/helm/auth/templates/auth-user-mark-for-deletion-cron-task.yml
+++ b/_infra/helm/auth/templates/auth-user-mark-for-deletion-cron-task.yml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Values.crons.markUsersForDeletionScheduler.name }}


### PR DESCRIPTION
# What and why?
This PR updates the CronJob version from v1beta to v1
# How to test?
Deploying to case via helm, ```helm install auth ./_infra/helm/auth``` The change from v1beta to v1 was tested here aswell https://github.com/ONSdigital/ras-party/pull/390
# Trello

