### PR TITLE
Initial commit of temp deactivation of delete user crons

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
         if: github.ref != 'refs/heads/main'
         run: |
           docker build -t "$REGISTRY_HOSTNAME"/"$HOST"/"$IMAGE":${{ steps.tag.outputs.pr_number }} -f _infra/docker/Dockerfile .
-          docker build -t "$REGISTRY_HOSTNAME"/"$HOST"/"$SCHEDULER_IMAGE":${{ steps.tag.outputs.pr_number }} -f _infra/docker/scheduler.Dockerfile .
+#          docker build -t "$REGISTRY_HOSTNAME"/"$HOST"/"$SCHEDULER_IMAGE":${{ steps.tag.outputs.pr_number }} -f _infra/docker/scheduler.Dockerfile .
       - name: Push dev image
         if: github.ref != 'refs/heads/main'
         run: |
@@ -167,7 +167,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           docker build -f _infra/docker/Dockerfile -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":latest -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ steps.release.outputs.version }} .
-          docker build -f _infra/docker/scheduler.Dockerfile -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$SCHEDULER_IMAGE":latest -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$SCHEDULER_IMAGE":${{ steps.release.outputs.version }} .
+#          docker build -f _infra/docker/scheduler.Dockerfile -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$SCHEDULER_IMAGE":latest -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$SCHEDULER_IMAGE":${{ steps.release.outputs.version }} .
       - name: Push Release image
         if: github.ref == 'refs/heads/main'
         run: |

--- a/_infra/helm/auth/values.yaml
+++ b/_infra/helm/auth/values.yaml
@@ -51,24 +51,24 @@ dns:
   enabled: false
   wellKnownPort: 8080
 
-crons:
-  deleteUsersScheduler:
-    name: auth-delete-users-scheduled-job
-    cron: "0 0 * * *"
-    target: "/api/batch/account/users"
-  markUsersForDeletionScheduler:
-    name: auth-mark-users-for-deletion-scheduled-job
-    cron: "0 1 * * *"
-    target: "/api/batch/account/users/mark-for-deletion"
-  dueDeletionNotificationScheduler:
-    name: auth-due-deletion-notification-scheduled-job
-    cron: "0 2 * * *"
-    image: auth-scheduler
+#crons:
+#  deleteUsersScheduler:
+#    name: auth-delete-users-scheduled-job
+#    cron: "0 0 * * *"
+#    target: "/api/batch/account/users"
+#  markUsersForDeletionScheduler:
+#    name: auth-mark-users-for-deletion-scheduled-job
+#    cron: "0 1 * * *"
+#    target: "/api/batch/account/users/mark-for-deletion"
+#  dueDeletionNotificationScheduler:
+#    name: auth-due-deletion-notification-scheduled-job
+#    cron: "0 2 * * *"
+#    image: auth-scheduler
 
-notify:
-  dueDeletionFirstNotificationTemplate: due_deletion_first_notification_templates
-  dueDeletionSecondNotificationTemplate: due_deletion_second_notification_templates
-  dueDeletionThirdNotificationTemplate: due_deletion_third_notification_templates
+#notify:
+#  dueDeletionFirstNotificationTemplate: due_deletion_first_notification_templates
+#  dueDeletionSecondNotificationTemplate: due_deletion_second_notification_templates
+#  dueDeletionThirdNotificationTemplate: due_deletion_third_notification_templates
 
 sendEmailToGovNotify: true
 

--- a/config.py
+++ b/config.py
@@ -14,15 +14,15 @@ class Config(object):
     PARTY_URL = os.getenv("PARTY_URL")
     AUTH_URL = os.getenv("AUTH_URL")
     BASIC_AUTH = (SECURITY_USER_NAME, SECURITY_USER_PASSWORD)
-    DUE_DELETION_FIRST_NOTIFICATION_TEMPLATE = os.getenv(
-        "DUE_DELETION_FIRST_NOTIFICATION_TEMPLATE", "due_deletion_first_notification_templates"
-    )
-    DUE_DELETION_SECOND_NOTIFICATION_TEMPLATE = os.getenv(
-        "DUE_DELETION_SECOND_NOTIFICATION_TEMPLATE", "due_deletion_second_notification_templates"
-    )
-    DUE_DELETION_THIRD_NOTIFICATION_TEMPLATE = os.getenv(
-        "DUE_DELETION_THIRD_NOTIFICATION_TEMPLATE", "due_deletion_third_notification_templates"
-    )
+    # DUE_DELETION_FIRST_NOTIFICATION_TEMPLATE = os.getenv(
+    #     "DUE_DELETION_FIRST_NOTIFICATION_TEMPLATE", "due_deletion_first_notification_templates"
+    # )
+    # DUE_DELETION_SECOND_NOTIFICATION_TEMPLATE = os.getenv(
+    #     "DUE_DELETION_SECOND_NOTIFICATION_TEMPLATE", "due_deletion_second_notification_templates"
+    # )
+    # DUE_DELETION_THIRD_NOTIFICATION_TEMPLATE = os.getenv(
+    #     "DUE_DELETION_THIRD_NOTIFICATION_TEMPLATE", "due_deletion_third_notification_templates"
+    # )
     SEND_EMAIL_TO_GOV_NOTIFY = os.getenv("SEND_EMAIL_TO_GOV_NOTIFY", True)
     PUBSUB_TOPIC = os.getenv("PUBSUB_TOPIC", "ras-rm-notify-test")
     GOOGLE_CLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT", "test-project-id")

--- a/test/scheduler_service/test_notify_service.py
+++ b/test/scheduler_service/test_notify_service.py
@@ -1,62 +1,62 @@
-import unittest
-from unittest.mock import MagicMock, patch
-
-from ras_rm_auth_scheduler_service.notify_service import NotifyError, NotifyService
-
-
-class TestNotifyService(unittest.TestCase):
-    """
-    Tests that the notify service is working as expected
-    """
-
-    def test_an_invalid_template_id(self):
-        with self.assertRaises(KeyError):
-            notify = NotifyService()
-            notify._get_template_id(template_name="invalid_template")
-
-    def test_a_valid_template_id(self):
-        notify = NotifyService()
-        template_id = notify._get_template_id(template_name="first_notification")
-        self.assertEqual(template_id, "due_deletion_first_notification_templates")
-
-    def test_a_successful_send_to_pub_sub(self):
-        with patch("ras_rm_auth_scheduler_service.notify_service.NotifyService._get_user_first_name") as mock_request:
-            mock_request.return_value = "test"
-            publisher = MagicMock()
-            publisher.topic_path.return_value = "projects/test-project-id/topics/ras-rm-notify-test"
-            notify = NotifyService()
-            notify.publisher = publisher
-            result = notify.request_to_notify(email="test@test.test", template_name="first_notification")
-            data = (
-                b'{"notify": {"email_address": "test@test.test", '
-                b'"template_id": "due_deletion_first_notification_templates", "personalisation": {"FIRST_NAME": '
-                b'"test"}}}'
-            )
-
-            publisher.publish.assert_called()
-            publisher.publish.assert_called_with("projects/test-project-id/topics/ras-rm-notify-test", data=data)
-            self.assertIsNone(result)
-
-    def test_a_unsuccessful_send_to_pub_sub(self):
-        with patch("ras_rm_auth_scheduler_service.notify_service.NotifyService._get_user_first_name") as mock_request:
-            mock_request.return_value = "test"
-            future = MagicMock()
-            future.result.side_effect = TimeoutError("bad")
-            publisher = MagicMock()
-            publisher.publish.return_value = future
-            notify = NotifyService()
-            notify.publisher = publisher
-            with self.assertRaises(NotifyError):
-                notify.request_to_notify(email="test@test.test", template_name="first_notification")
-
-    def test_a_unsuccessful_send_to_pub_sub_with_exception(self):
-        with patch("ras_rm_auth_scheduler_service.notify_service.NotifyService._get_user_first_name") as mock_request:
-            mock_request.return_value = "test"
-            future = MagicMock()
-            future.result.side_effect = Exception("bad")
-            publisher = MagicMock()
-            publisher.publish.return_value = future
-            notify = NotifyService()
-            notify.publisher = publisher
-            with self.assertRaises(NotifyError):
-                notify.request_to_notify(email="test@test.test", template_name="first_notification")
+# import unittest
+# from unittest.mock import MagicMock, patch
+#
+# from ras_rm_auth_scheduler_service.notify_service import NotifyError, NotifyService
+#
+#
+# class TestNotifyService(unittest.TestCase):
+#     """
+#     Tests that the notify service is working as expected
+#     """
+#
+#     def test_an_invalid_template_id(self):
+#         with self.assertRaises(KeyError):
+#             notify = NotifyService()
+#             notify._get_template_id(template_name="invalid_template")
+#
+#     def test_a_valid_template_id(self):
+#         notify = NotifyService()
+#         template_id = notify._get_template_id(template_name="first_notification")
+#         self.assertEqual(template_id, "due_deletion_first_notification_templates")
+#
+#     def test_a_successful_send_to_pub_sub(self):
+#         with patch("ras_rm_auth_scheduler_service.notify_service.NotifyService._get_user_first_name") as mock_request:
+#             mock_request.return_value = "test"
+#             publisher = MagicMock()
+#             publisher.topic_path.return_value = "projects/test-project-id/topics/ras-rm-notify-test"
+#             notify = NotifyService()
+#             notify.publisher = publisher
+#             result = notify.request_to_notify(email="test@test.test", template_name="first_notification")
+#             data = (
+#                 b'{"notify": {"email_address": "test@test.test", '
+#                 b'"template_id": "due_deletion_first_notification_templates", "personalisation": {"FIRST_NAME": '
+#                 b'"test"}}}'
+#             )
+#
+#             publisher.publish.assert_called()
+#             publisher.publish.assert_called_with("projects/test-project-id/topics/ras-rm-notify-test", data=data)
+#             self.assertIsNone(result)
+#
+#     def test_a_unsuccessful_send_to_pub_sub(self):
+#         with patch("ras_rm_auth_scheduler_service.notify_service.NotifyService._get_user_first_name") as mock_request:
+#             mock_request.return_value = "test"
+#             future = MagicMock()
+#             future.result.side_effect = TimeoutError("bad")
+#             publisher = MagicMock()
+#             publisher.publish.return_value = future
+#             notify = NotifyService()
+#             notify.publisher = publisher
+#             with self.assertRaises(NotifyError):
+#                 notify.request_to_notify(email="test@test.test", template_name="first_notification")
+#
+#     def test_a_unsuccessful_send_to_pub_sub_with_exception(self):
+#         with patch("ras_rm_auth_scheduler_service.notify_service.NotifyService._get_user_first_name") as mock_request:
+#             mock_request.return_value = "test"
+#             future = MagicMock()
+#             future.result.side_effect = Exception("bad")
+#             publisher = MagicMock()
+#             publisher.publish.return_value = future
+#             notify = NotifyService()
+#             notify.publisher = publisher
+#             with self.assertRaises(NotifyError):
+#                 notify.request_to_notify(email="test@test.test", template_name="first_notification")

--- a/test/scheduler_service/test_process_due_deletion_notification_job.py
+++ b/test/scheduler_service/test_process_due_deletion_notification_job.py
@@ -1,166 +1,166 @@
-import unittest
-from collections import namedtuple
-from unittest.mock import Mock, patch
-
-import requests
-
-from ras_rm_auth_scheduler_service.process_due_deletion_notification_job import (
-    ProcessNotificationJob,
-)
-
-fake_response = namedtuple("Response", "status_code json")
-
-
-class TestNotificationJob(unittest.TestCase):
-    def test_successful_first_notification(self):
-        with patch("ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.get") as mock_get:
-            with patch(
-                "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.patch"
-            ) as mock_patch:
-                with patch(
-                    "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService"
-                    ".request_to_notify"
-                ) as mock_notify:
-                    mock_notify.return_value = Mock()
-                    mock_get.return_value = fake_response(
-                        status_code=200, json=lambda: ["dummy@email.com", "dummy1@email.com", "dummy2@email.com"]
-                    )
-                    mock_patch.return_value = fake_response(status_code=204, json=lambda: [])
-                    ProcessNotificationJob().process_first_notification()
-                    self.assertEqual(mock_notify.call_count, 3)
-                    self.assertEqual(mock_get.call_count, 1)
-                    self.assertEqual(mock_patch.call_count, 3)
-
-    def test_no_notification_required_for_first_notification(self):
-        with patch("ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.get") as mock_get:
-            with patch(
-                "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.patch"
-            ) as mock_patch:
-                with patch(
-                    "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService"
-                    ".request_to_notify"
-                ) as mock_notify:
-                    mock_notify.return_value = Mock()
-                    mock_get.return_value = fake_response(status_code=200, json=lambda: [])
-                    mock_patch.return_value = fake_response(status_code=204, json=lambda: [])
-                    ProcessNotificationJob().process_first_notification()
-                    self.assertEqual(mock_notify.call_count, 0)
-                    self.assertEqual(mock_get.call_count, 1)
-                    self.assertEqual(mock_patch.call_count, 0)
-
-    def test_no_connection_for_first_notification(self):
-        with patch("ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.get") as mock_get:
-            with patch(
-                "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.patch"
-            ) as mock_patch:
-                with patch(
-                    "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService"
-                    ".request_to_notify"
-                ) as mock_notify:
-                    mock_notify.return_value = Mock()
-                    mock_get.side_effect = requests.exceptions.HTTPError("error")
-                    mock_patch.side_effect = requests.exceptions.HTTPError("error")
-                with self.assertRaises(requests.exceptions.HTTPError):
-                    ProcessNotificationJob().process_first_notification()
-
-    def test_successful_second_notification(self):
-        with patch("ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.get") as mock_get:
-            with patch(
-                "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.patch"
-            ) as mock_patch:
-                with patch(
-                    "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService"
-                    ".request_to_notify"
-                ) as mock_notify:
-                    mock_notify.return_value = Mock()
-                    mock_get.return_value = fake_response(
-                        status_code=200, json=lambda: ["dummy@email.com", "dummy1@email.com", "dummy2@email.com"]
-                    )
-                    mock_patch.return_value = fake_response(status_code=204, json=lambda: [])
-                    ProcessNotificationJob().process_second_notification()
-                    self.assertEqual(mock_notify.call_count, 3)
-                    self.assertEqual(mock_get.call_count, 1)
-                    self.assertEqual(mock_patch.call_count, 3)
-
-    def test_no_notification_required_for_second_notification(self):
-        with patch("ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.get") as mock_get:
-            with patch(
-                "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.patch"
-            ) as mock_patch:
-                with patch(
-                    "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService"
-                    ".request_to_notify"
-                ) as mock_notify:
-                    mock_notify.return_value = Mock()
-                    mock_get.return_value = fake_response(status_code=200, json=lambda: [])
-                    mock_patch.return_value = fake_response(status_code=204, json=lambda: [])
-                    ProcessNotificationJob().process_second_notification()
-                    self.assertEqual(mock_notify.call_count, 0)
-                    self.assertEqual(mock_get.call_count, 1)
-                    self.assertEqual(mock_patch.call_count, 0)
-
-    def test_no_connection_for_second_notification(self):
-        with patch("ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.get") as mock_get:
-            with patch(
-                "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.patch"
-            ) as mock_patch:
-                with patch(
-                    "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService"
-                    ".request_to_notify"
-                ) as mock_notify:
-                    mock_notify.return_value = Mock()
-                    mock_get.side_effect = requests.exceptions.HTTPError("error")
-                    mock_patch.side_effect = requests.exceptions.HTTPError("error")
-                with self.assertRaises(requests.exceptions.HTTPError):
-                    ProcessNotificationJob().process_second_notification()
-
-    def test_successful_third_notification(self):
-        with patch("ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.get") as mock_get:
-            with patch(
-                "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.patch"
-            ) as mock_patch:
-                with patch(
-                    "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService"
-                    ".request_to_notify"
-                ) as mock_notify:
-                    mock_notify.return_value = Mock()
-                    mock_get.return_value = fake_response(
-                        status_code=200, json=lambda: ["dummy@email.com", "dummy1@email.com", "dummy2@email.com"]
-                    )
-                    mock_patch.return_value = fake_response(status_code=204, json=lambda: [])
-                    ProcessNotificationJob().process_third_notification()
-                    self.assertEqual(mock_notify.call_count, 3)
-                    self.assertEqual(mock_get.call_count, 1)
-                    self.assertEqual(mock_patch.call_count, 3)
-
-    def test_no_notification_required_for_third_notification(self):
-        with patch("ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.get") as mock_get:
-            with patch(
-                "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.patch"
-            ) as mock_patch:
-                with patch(
-                    "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService"
-                    ".request_to_notify"
-                ) as mock_notify:
-                    mock_notify.return_value = Mock()
-                    mock_get.return_value = fake_response(status_code=200, json=lambda: [])
-                    mock_patch.return_value = fake_response(status_code=204, json=lambda: [])
-                    ProcessNotificationJob().process_third_notification()
-                    self.assertEqual(mock_notify.call_count, 0)
-                    self.assertEqual(mock_get.call_count, 1)
-                    self.assertEqual(mock_patch.call_count, 0)
-
-    def test_no_connection_for_third_notification(self):
-        with patch("ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.get") as mock_get:
-            with patch(
-                "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.patch"
-            ) as mock_patch:
-                with patch(
-                    "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService"
-                    ".request_to_notify"
-                ) as mock_notify:
-                    mock_notify.return_value = Mock()
-                    mock_get.side_effect = requests.exceptions.HTTPError("error")
-                    mock_patch.side_effect = requests.exceptions.HTTPError("error")
-                with self.assertRaises(requests.exceptions.HTTPError):
-                    ProcessNotificationJob().process_third_notification()
+# import unittest
+# from collections import namedtuple
+# from unittest.mock import Mock, patch
+#
+# import requests
+#
+# from ras_rm_auth_scheduler_service.process_due_deletion_notification_job import (
+#     ProcessNotificationJob,
+# )
+#
+# fake_response = namedtuple("Response", "status_code json")
+#
+#
+# class TestNotificationJob(unittest.TestCase):
+#     def test_successful_first_notification(self):
+#         with patch("ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.get") as mock_get:
+#             with patch(
+#                 "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.patch"
+#             ) as mock_patch:
+#                 with patch(
+#                     "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService"
+#                     ".request_to_notify"
+#                 ) as mock_notify:
+#                     mock_notify.return_value = Mock()
+#                     mock_get.return_value = fake_response(
+#                         status_code=200, json=lambda: ["dummy@email.com", "dummy1@email.com", "dummy2@email.com"]
+#                     )
+#                     mock_patch.return_value = fake_response(status_code=204, json=lambda: [])
+#                     ProcessNotificationJob().process_first_notification()
+#                     self.assertEqual(mock_notify.call_count, 3)
+#                     self.assertEqual(mock_get.call_count, 1)
+#                     self.assertEqual(mock_patch.call_count, 3)
+#
+#     def test_no_notification_required_for_first_notification(self):
+#         with patch("ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.get") as mock_get:
+#             with patch(
+#                 "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.patch"
+#             ) as mock_patch:
+#                 with patch(
+#                     "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService"
+#                     ".request_to_notify"
+#                 ) as mock_notify:
+#                     mock_notify.return_value = Mock()
+#                     mock_get.return_value = fake_response(status_code=200, json=lambda: [])
+#                     mock_patch.return_value = fake_response(status_code=204, json=lambda: [])
+#                     ProcessNotificationJob().process_first_notification()
+#                     self.assertEqual(mock_notify.call_count, 0)
+#                     self.assertEqual(mock_get.call_count, 1)
+#                     self.assertEqual(mock_patch.call_count, 0)
+#
+#     def test_no_connection_for_first_notification(self):
+#         with patch("ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.get") as mock_get:
+#             with patch(
+#                 "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.patch"
+#             ) as mock_patch:
+#                 with patch(
+#                     "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService"
+#                     ".request_to_notify"
+#                 ) as mock_notify:
+#                     mock_notify.return_value = Mock()
+#                     mock_get.side_effect = requests.exceptions.HTTPError("error")
+#                     mock_patch.side_effect = requests.exceptions.HTTPError("error")
+#                 with self.assertRaises(requests.exceptions.HTTPError):
+#                     ProcessNotificationJob().process_first_notification()
+#
+#     def test_successful_second_notification(self):
+#         with patch("ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.get") as mock_get:
+#             with patch(
+#                 "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.patch"
+#             ) as mock_patch:
+#                 with patch(
+#                     "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService"
+#                     ".request_to_notify"
+#                 ) as mock_notify:
+#                     mock_notify.return_value = Mock()
+#                     mock_get.return_value = fake_response(
+#                         status_code=200, json=lambda: ["dummy@email.com", "dummy1@email.com", "dummy2@email.com"]
+#                     )
+#                     mock_patch.return_value = fake_response(status_code=204, json=lambda: [])
+#                     ProcessNotificationJob().process_second_notification()
+#                     self.assertEqual(mock_notify.call_count, 3)
+#                     self.assertEqual(mock_get.call_count, 1)
+#                     self.assertEqual(mock_patch.call_count, 3)
+#
+#     def test_no_notification_required_for_second_notification(self):
+#         with patch("ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.get") as mock_get:
+#             with patch(
+#                 "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.patch"
+#             ) as mock_patch:
+#                 with patch(
+#                     "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService"
+#                     ".request_to_notify"
+#                 ) as mock_notify:
+#                     mock_notify.return_value = Mock()
+#                     mock_get.return_value = fake_response(status_code=200, json=lambda: [])
+#                     mock_patch.return_value = fake_response(status_code=204, json=lambda: [])
+#                     ProcessNotificationJob().process_second_notification()
+#                     self.assertEqual(mock_notify.call_count, 0)
+#                     self.assertEqual(mock_get.call_count, 1)
+#                     self.assertEqual(mock_patch.call_count, 0)
+#
+#     def test_no_connection_for_second_notification(self):
+#         with patch("ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.get") as mock_get:
+#             with patch(
+#                 "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.patch"
+#             ) as mock_patch:
+#                 with patch(
+#                     "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService"
+#                     ".request_to_notify"
+#                 ) as mock_notify:
+#                     mock_notify.return_value = Mock()
+#                     mock_get.side_effect = requests.exceptions.HTTPError("error")
+#                     mock_patch.side_effect = requests.exceptions.HTTPError("error")
+#                 with self.assertRaises(requests.exceptions.HTTPError):
+#                     ProcessNotificationJob().process_second_notification()
+#
+#     def test_successful_third_notification(self):
+#         with patch("ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.get") as mock_get:
+#             with patch(
+#                 "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.patch"
+#             ) as mock_patch:
+#                 with patch(
+#                     "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService"
+#                     ".request_to_notify"
+#                 ) as mock_notify:
+#                     mock_notify.return_value = Mock()
+#                     mock_get.return_value = fake_response(
+#                         status_code=200, json=lambda: ["dummy@email.com", "dummy1@email.com", "dummy2@email.com"]
+#                     )
+#                     mock_patch.return_value = fake_response(status_code=204, json=lambda: [])
+#                     ProcessNotificationJob().process_third_notification()
+#                     self.assertEqual(mock_notify.call_count, 3)
+#                     self.assertEqual(mock_get.call_count, 1)
+#                     self.assertEqual(mock_patch.call_count, 3)
+#
+#     def test_no_notification_required_for_third_notification(self):
+#         with patch("ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.get") as mock_get:
+#             with patch(
+#                 "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.patch"
+#             ) as mock_patch:
+#                 with patch(
+#                     "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService"
+#                     ".request_to_notify"
+#                 ) as mock_notify:
+#                     mock_notify.return_value = Mock()
+#                     mock_get.return_value = fake_response(status_code=200, json=lambda: [])
+#                     mock_patch.return_value = fake_response(status_code=204, json=lambda: [])
+#                     ProcessNotificationJob().process_third_notification()
+#                     self.assertEqual(mock_notify.call_count, 0)
+#                     self.assertEqual(mock_get.call_count, 1)
+#                     self.assertEqual(mock_patch.call_count, 0)
+#
+#     def test_no_connection_for_third_notification(self):
+#         with patch("ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.get") as mock_get:
+#             with patch(
+#                 "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.requests.patch"
+#             ) as mock_patch:
+#                 with patch(
+#                     "ras_rm_auth_scheduler_service.process_due_deletion_notification_job.NotifyService"
+#                     ".request_to_notify"
+#                 ) as mock_notify:
+#                     mock_notify.return_value = Mock()
+#                     mock_get.side_effect = requests.exceptions.HTTPError("error")
+#                     mock_patch.side_effect = requests.exceptions.HTTPError("error")
+#                 with self.assertRaises(requests.exceptions.HTTPError):
+#                     ProcessNotificationJob().process_third_notification()


### PR DESCRIPTION
# What and why?
Temporarily turn off the delete user accounts cron until a further discussion is had.
# How to test?

# Trello
