### PR TITLE
RAS-1469 Improve auditing or logging for auth account deletions

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -462,11 +462,12 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369",
-                "sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"
+                "sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb",
+                "sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==3.1.4"
+            "version": "==3.1.5"
         },
         "mako": {
             "hashes": [

--- a/_infra/helm/auth/Chart.yaml
+++ b/_infra/helm/auth/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.1.69
+version: 2.1.70
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.1.69
+appVersion: 2.1.70

--- a/ras_rm_auth_service/batch_process_endpoints.py
+++ b/ras_rm_auth_service/batch_process_endpoints.py
@@ -39,13 +39,13 @@ def delete_accounts():
         logger.info("Scheduler deleting users marked for deletion")
         with transactional_session() as session:
             marked_for_deletion_users = session.query(User).filter(User.mark_for_deletion == True)  # noqa
-            marked_for_deletion_count = marked_for_deletion_users.count()
-            if marked_for_deletion_count > 0:
-                logger.info(f"{marked_for_deletion_count} users marked for deletion")
+            total_users_to_delete = marked_for_deletion_users.count()
+            if total_users_to_delete > 0:
+                logger.info(f"{total_users_to_delete} users marked for deletion")
                 logger.info("sending request to party service to remove ")
                 delete_party_respondents_and_auth_user(marked_for_deletion_users, session)
-                failed_to_delete_count = marked_for_deletion_count - marked_for_deletion_users.count()
-                successfully_deleted_count = marked_for_deletion_count - failed_to_delete_count
+                failed_to_delete_count = total_users_to_delete - marked_for_deletion_users.count()
+                successfully_deleted_count = total_users_to_delete - failed_to_delete_count
                 logger.info(f"Scheduler successfully deleted {successfully_deleted_count} users marked for deletion")
             else:
                 logger.info("No user marked for deletion at this time. Nothing to delete.")

--- a/ras_rm_auth_service/batch_process_endpoints.py
+++ b/ras_rm_auth_service/batch_process_endpoints.py
@@ -40,8 +40,8 @@ def delete_accounts():
         with transactional_session() as session:
             marked_for_deletion_users = session.query(User).filter(User.mark_for_deletion == True)  # noqa
             marked_for_deletion_count = marked_for_deletion_users.count()
-            logger.info(f"{marked_for_deletion_count} users marked for deletion")
             if marked_for_deletion_count > 0:
+                logger.info(f"{marked_for_deletion_count} users marked for deletion")
                 logger.info("sending request to party service to remove ")
                 delete_party_respondents_and_auth_user(marked_for_deletion_users, session)
                 successfully_deleted_count = marked_for_deletion_count - marked_for_deletion_users.count()

--- a/ras_rm_auth_service/batch_process_endpoints.py
+++ b/ras_rm_auth_service/batch_process_endpoints.py
@@ -39,14 +39,14 @@ def delete_accounts():
         logger.info("Scheduler deleting users marked for deletion")
         with transactional_session() as session:
             marked_for_deletion_users = session.query(User).filter(User.mark_for_deletion == True)  # noqa
-            total_users_to_delete = marked_for_deletion_users.count()
-            if total_users_to_delete > 0:
-                logger.info(f"{total_users_to_delete} users marked for deletion")
+            expected_number_of_users_to_delete = marked_for_deletion_users.count()
+            if expected_number_of_users_to_delete > 0:
+                logger.info(f"{expected_number_of_users_to_delete} users marked for deletion")
                 logger.info("sending request to party service to remove ")
                 delete_party_respondents_and_auth_user(marked_for_deletion_users, session)
-                failed_to_delete_count = total_users_to_delete - marked_for_deletion_users.count()
-                successfully_deleted_count = total_users_to_delete - failed_to_delete_count
-                logger.info(f"Scheduler successfully deleted {successfully_deleted_count} users marked for deletion")
+                number_of_failed_user_deletions = expected_number_of_users_to_delete - marked_for_deletion_users.count()
+                total_users_deleted = expected_number_of_users_to_delete - number_of_failed_user_deletions
+                logger.info(f"Scheduler successfully deleted {total_users_deleted} users marked for deletion")
             else:
                 logger.info("No user marked for deletion at this time. Nothing to delete.")
 

--- a/ras_rm_auth_service/batch_process_endpoints.py
+++ b/ras_rm_auth_service/batch_process_endpoints.py
@@ -44,7 +44,8 @@ def delete_accounts():
                 logger.info(f"{marked_for_deletion_count} users marked for deletion")
                 logger.info("sending request to party service to remove ")
                 delete_party_respondents_and_auth_user(marked_for_deletion_users, session)
-                successfully_deleted_count = marked_for_deletion_count - marked_for_deletion_users.count()
+                failed_to_delete_count = marked_for_deletion_count - marked_for_deletion_users.count()
+                successfully_deleted_count = marked_for_deletion_count - failed_to_delete_count
                 logger.info(f"Scheduler successfully deleted {successfully_deleted_count} users marked for deletion")
             else:
                 logger.info("No user marked for deletion at this time. Nothing to delete.")

--- a/ras_rm_auth_service/batch_process_endpoints.py
+++ b/ras_rm_auth_service/batch_process_endpoints.py
@@ -39,10 +39,13 @@ def delete_accounts():
         logger.info("Scheduler deleting users marked for deletion")
         with transactional_session() as session:
             marked_for_deletion_users = session.query(User).filter(User.mark_for_deletion == True)  # noqa
-            if marked_for_deletion_users.count() > 0:
+            marked_for_deletion_count = marked_for_deletion_users.count()
+            logger.info(f"{marked_for_deletion_count} users marked for deletion")
+            if marked_for_deletion_count > 0:
                 logger.info("sending request to party service to remove ")
                 delete_party_respondents_and_auth_user(marked_for_deletion_users, session)
-                logger.info("Scheduler successfully deleted users marked for deletion")
+                successfully_deleted_count = marked_for_deletion_count - marked_for_deletion_users.count()
+                logger.info(f"Scheduler successfully deleted {successfully_deleted_count} users marked for deletion")
             else:
                 logger.info("No user marked for deletion at this time. Nothing to delete.")
 


### PR DESCRIPTION
# What and why?
Adding a few new log lines to help us understand if and how many user accounts were meant to be deleted, and how many were successfully deleted
# How to test?
- deploy this PR to your env
- run acceptance tests in your env
- run `kubectl create job auth-delete-cron-job --from=cronjob/auth-delete-users-scheduled-job`
- check auth logs and make sure the new log lines have not been generated
- go into the database `auth.user` table and set the account as marked for deletion
- delete the job you just created with `kubectl delete job auth-delete-cron-job`
- run `kubectl create job auth-delete-cron-job --from=cronjob/auth-delete-users-scheduled-job`
- check that the new log lines have been created with the correct numbers in the logs
# Jira
[RAS-1469](https://jira.ons.gov.uk/browse/RAS-1469)