### PR TITLE
RAS-1533 Replace deprecated datetime.utcnow() in auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,13 @@ build:
 	pipenv install --dev
 
 lint:
-	pipenv check --ignore=70612
+	pipenv check --ignore=75976
 	pipenv run isort .
 	pipenv run black --line-length 120 .
 	pipenv run flake8
 
 lint-check:
-	pipenv check --ignore=70612
+	pipenv check --ignore=75976
 	pipenv run isort --check-only .
 	pipenv run black --line-length 120 --check .
 	pipenv run flake8

--- a/_infra/helm/auth/Chart.yaml
+++ b/_infra/helm/auth/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.1.70
+version: 2.1.71
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.1.70
+appVersion: 2.1.71

--- a/ras_rm_auth_scheduler_service/process_due_deletion_notification_job.py
+++ b/ras_rm_auth_scheduler_service/process_due_deletion_notification_job.py
@@ -1,5 +1,5 @@
 import base64
-from datetime import datetime
+from datetime import UTC, datetime
 
 import requests
 
@@ -49,7 +49,7 @@ class ProcessNotificationJob:
 
     def _update_user(self, user, scheduler_column):
         logger.info("Updating user data with notification sent date", notification=scheduler_column)
-        form_data = {scheduler_column: datetime.utcnow()}
+        form_data = {scheduler_column: datetime.now(UTC)}
         try:
             requests.patch(f"{self.patch_url}/{user}", data=form_data, headers=self.headers)
         except requests.exceptions.HTTPError as error:

--- a/ras_rm_auth_service/batch_process_endpoints.py
+++ b/ras_rm_auth_service/batch_process_endpoints.py
@@ -1,6 +1,6 @@
 import base64
 import logging
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from itertools import chain
 
 import requests
@@ -63,8 +63,8 @@ def delete_accounts():
 
 @batch.route("users/eligible-for-first-notification", methods=["GET"])
 def get_users_eligible_for_first_notification():
-    _datetime_24_months_ago = datetime.utcnow() - timedelta(days=730)
-    _datetime_30_months_ago = datetime.utcnow() - timedelta(days=913)
+    _datetime_24_months_ago = datetime.now(UTC) - timedelta(days=730)
+    _datetime_30_months_ago = datetime.now(UTC) - timedelta(days=913)
     try:
         with transactional_session() as session:
             logger.info("Getting users eligible for fist due deletion notification")
@@ -95,8 +95,8 @@ def get_users_eligible_for_first_notification():
 
 @batch.route("users/eligible-for-second-notification", methods=["GET"])
 def get_users_eligible_for_second_notification():
-    _datetime_30_months_ago = datetime.utcnow() - timedelta(days=913)
-    _datetime_35_months_ago = datetime.utcnow() - timedelta(days=1065)
+    _datetime_30_months_ago = datetime.now(UTC) - timedelta(days=913)
+    _datetime_35_months_ago = datetime.now(UTC) - timedelta(days=1065)
     try:
         with transactional_session() as session:
             logger.info("Getting users eligible for second due deletion notification")
@@ -127,8 +127,8 @@ def get_users_eligible_for_second_notification():
 
 @batch.route("users/eligible-for-third-notification", methods=["GET"])
 def get_users_eligible_for_third_notification():
-    _datetime_35_months_ago = datetime.utcnow() - timedelta(days=1065)
-    _datetime_36_months_ago = datetime.utcnow() - timedelta(days=1095)
+    _datetime_35_months_ago = datetime.now(UTC) - timedelta(days=1065)
+    _datetime_36_months_ago = datetime.now(UTC) - timedelta(days=1095)
     try:
         with transactional_session() as session:
             logger.info("Getting users eligible for third due deletion notification")
@@ -168,7 +168,7 @@ def mark_for_deletion_accounts():
             logger.info("Scheduler processing Accounts not accessed in the last 36 months ")
             # process to mark account ready for deletion for
             # accounts not accessed in the last 36 months
-            _since_36_months = datetime.utcnow() - timedelta(days=1095)
+            _since_36_months = datetime.now(UTC) - timedelta(days=1095)
             _last_login_before_36_months = session.query(User).filter(
                 and_(User.last_login_date != None, User.last_login_date < _since_36_months)  # noqa
             )
@@ -181,7 +181,7 @@ def mark_for_deletion_accounts():
             # process to mark account ready for deletion for
             # accounts not been activated in the last 80 hrs.
             logger.info("Scheduler processing Account not activated for more than 80 hrs")
-            _since_80_hrs = datetime.utcnow() - timedelta(hours=80)
+            _since_80_hrs = datetime.now(UTC) - timedelta(hours=80)
             _account_not_activated_80_hrs = session.query(User).filter(
                 and_(User.account_verified == False, User.account_creation_date < _since_80_hrs)  # noqa
             )

--- a/ras_rm_auth_service/models/models.py
+++ b/ras_rm_auth_service/models/models.py
@@ -1,10 +1,10 @@
 import logging
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 from distutils.util import strtobool
 
 import bcrypt
 from marshmallow import Schema, fields, validate
-from sqlalchemy import Boolean, Column, DateTime, Integer, String, Text
+from sqlalchemy import Boolean, Column, DateTime, Integer, String, Text, func
 from sqlalchemy.orm import declarative_base
 from structlog import wrap_logger
 from werkzeug.exceptions import Unauthorized
@@ -29,7 +29,7 @@ class User(Base):
     account_locked = Column(Boolean, default=False, nullable=False)
     failed_logins = Column(Integer, default=0, nullable=False)
     last_login_date = Column(DateTime, default=None, nullable=True)
-    account_creation_date = Column(DateTime, default=datetime.utcnow)
+    account_creation_date = Column(DateTime, default=func.now())
     first_notification = Column(DateTime, default=None, nullable=True)
     second_notification = Column(DateTime, default=None, nullable=True)
     third_notification = Column(DateTime, default=None, nullable=True)
@@ -42,7 +42,7 @@ class User(Base):
 
         if "account_verified" in update_params:
             self.account_verified = strtobool(update_params["account_verified"])
-            self.account_verification_date = datetime.utcnow()
+            self.account_verification_date = datetime.now(UTC)
             if self.mark_for_deletion and not self.force_delete:
                 self.mark_for_deletion = False
 

--- a/test/resources/test_account.py
+++ b/test/resources/test_account.py
@@ -1,6 +1,6 @@
 import base64
 import unittest
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 from sqlalchemy.exc import SQLAlchemyError
@@ -522,7 +522,7 @@ class TestAccount(unittest.TestCase):
         """
         Test update first_notification
         """
-        time = datetime.utcnow()
+        time = datetime.now(UTC)
         # Given
         form_data = {"username": "testuser@email.com", "password": "password"}
         self.client.post("/api/account/create", data=form_data, headers=self.headers)
@@ -540,7 +540,7 @@ class TestAccount(unittest.TestCase):
         """
         Test update first_notification
         """
-        time = datetime.utcnow()
+        time = datetime.now(UTC)
         # Given
         form_data = {"username": "testuser@email.com", "password": "password"}
         self.client.post("/api/account/create", data=form_data, headers=self.headers)
@@ -558,7 +558,7 @@ class TestAccount(unittest.TestCase):
         """
         Test update first_notification
         """
-        time = datetime.utcnow()
+        time = datetime.now(UTC)
         # Given
         form_data = {"username": "testuser@email.com", "password": "password"}
         self.client.post("/api/account/create", data=form_data, headers=self.headers)

--- a/test/test_batch_process_endpoints.py
+++ b/test/test_batch_process_endpoints.py
@@ -1,6 +1,6 @@
 import base64
 import unittest
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import requests
@@ -306,7 +306,7 @@ class TestBatchProcessEndpoints(unittest.TestCase):
         criteria = {"account_creation_date": datetime(1999, 1, 1, 0, 0)}
         self.update_test_data(self.user_0, criteria)
         self.update_test_data(self.user_2, criteria)
-        self.update_test_data(self.user_2, {"last_login_date": datetime.utcnow()})
+        self.update_test_data(self.user_2, {"last_login_date": datetime.now(UTC)})
         self.update_test_data(self.user_2, {"account_verified": True})
         self.client.delete("/api/batch/account/users/mark-for-deletion", headers=self.headers)
         # Then:
@@ -324,7 +324,7 @@ class TestBatchProcessEndpoints(unittest.TestCase):
         # Given:
         self.batch_setup()
         # When:
-        criteria = {"account_creation_date": datetime.utcnow() - timedelta(hours=80)}
+        criteria = {"account_creation_date": datetime.now(UTC) - timedelta(hours=80)}
         self.update_test_data(self.user_0, criteria)
         self.update_test_data(self.user_2, criteria)
         self.client.delete("/api/batch/account/users/mark-for-deletion", headers=self.headers)
@@ -343,7 +343,7 @@ class TestBatchProcessEndpoints(unittest.TestCase):
         # Given:
         self.batch_setup()
         # When:
-        criteria = {"account_creation_date": datetime.utcnow() - timedelta(hours=80)}
+        criteria = {"account_creation_date": datetime.now(UTC) - timedelta(hours=80)}
         self.update_test_data(self.user_0, criteria)
         self.update_test_data(self.user_2, criteria)
         criteria = {"account_verified": True}
@@ -363,7 +363,7 @@ class TestBatchProcessEndpoints(unittest.TestCase):
         """
         # Given:
         self.batch_setup()
-        criteria = {"account_creation_date": datetime.utcnow() - timedelta(hours=80)}
+        criteria = {"account_creation_date": datetime.now(UTC) - timedelta(hours=80)}
         self.update_test_data(self.user_0, criteria)
         self.update_test_data(self.user_2, criteria)
         self.client.delete("/api/batch/account/users/mark-for-deletion", headers=self.headers)
@@ -388,7 +388,7 @@ class TestBatchProcessEndpoints(unittest.TestCase):
         # Given:
         self.batch_setup()
         # When:
-        _datetime_24_months_ago = datetime.utcnow() - timedelta(days=730)
+        _datetime_24_months_ago = datetime.now(UTC) - timedelta(days=730)
         criteria = {"last_login_date": _datetime_24_months_ago}
         self.update_test_data(self.user_0, criteria)
         self.update_test_data(self.user_2, criteria)
@@ -410,7 +410,7 @@ class TestBatchProcessEndpoints(unittest.TestCase):
         # Given:
         self.batch_setup()
         # When:
-        _datetime_24_months_ago = datetime.utcnow() - timedelta(days=730)
+        _datetime_24_months_ago = datetime.now(UTC) - timedelta(days=730)
         criteria_one = {"account_creation_date": _datetime_24_months_ago}
         criteria = {"last_login_date": None}
         self.update_test_data(self.user_0, criteria)
@@ -435,7 +435,7 @@ class TestBatchProcessEndpoints(unittest.TestCase):
         # Given:
         self.batch_setup()
         # When:
-        _datetime_24_months_ago = datetime.utcnow() - timedelta(days=750)
+        _datetime_24_months_ago = datetime.now(UTC) - timedelta(days=750)
         criteria = {"last_login_date": _datetime_24_months_ago}
         criteria_one = {"account_creation_date": _datetime_24_months_ago}
         self.update_test_data(self.user_0, criteria)
@@ -491,7 +491,7 @@ class TestBatchProcessEndpoints(unittest.TestCase):
         # Given:
         self.batch_setup()
         # When:
-        _datetime_30_months_ago = datetime.utcnow() - timedelta(days=913)
+        _datetime_30_months_ago = datetime.now(UTC) - timedelta(days=913)
         criteria = {"last_login_date": _datetime_30_months_ago}
         self.update_test_data(self.user_0, criteria)
         self.update_test_data(self.user_2, criteria)
@@ -513,7 +513,7 @@ class TestBatchProcessEndpoints(unittest.TestCase):
         # Given:
         self.batch_setup()
         # When:
-        _datetime_30_months_ago = datetime.utcnow() - timedelta(days=913)
+        _datetime_30_months_ago = datetime.now(UTC) - timedelta(days=913)
         criteria_one = {"account_creation_date": _datetime_30_months_ago}
         criteria = {"last_login_date": None}
         self.update_test_data(self.user_0, criteria)
@@ -538,7 +538,7 @@ class TestBatchProcessEndpoints(unittest.TestCase):
         # Given:
         self.batch_setup()
         # When:
-        _datetime_30_months_ago = datetime.utcnow() - timedelta(days=1064)
+        _datetime_30_months_ago = datetime.now(UTC) - timedelta(days=1064)
         criteria = {"last_login_date": _datetime_30_months_ago}
         criteria_one = {"account_creation_date": _datetime_30_months_ago}
         self.update_test_data(self.user_0, criteria)
@@ -594,7 +594,7 @@ class TestBatchProcessEndpoints(unittest.TestCase):
         # Given:
         self.batch_setup()
         # When:
-        _datetime_35_months_ago = datetime.utcnow() - timedelta(days=1065)
+        _datetime_35_months_ago = datetime.now(UTC) - timedelta(days=1065)
         criteria = {"last_login_date": _datetime_35_months_ago}
         self.update_test_data(self.user_0, criteria)
         self.update_test_data(self.user_2, criteria)
@@ -616,7 +616,7 @@ class TestBatchProcessEndpoints(unittest.TestCase):
         # Given:
         self.batch_setup()
         # When:
-        _datetime_35_months_ago = datetime.utcnow() - timedelta(days=1069)
+        _datetime_35_months_ago = datetime.now(UTC) - timedelta(days=1069)
         criteria_one = {"account_creation_date": _datetime_35_months_ago}
         criteria = {"last_login_date": None}
         self.update_test_data(self.user_0, criteria)
@@ -641,7 +641,7 @@ class TestBatchProcessEndpoints(unittest.TestCase):
         # Given:
         self.batch_setup()
         # When:
-        _datetime_35_months_ago = datetime.utcnow() - timedelta(days=1069)
+        _datetime_35_months_ago = datetime.now(UTC) - timedelta(days=1069)
         criteria = {"last_login_date": _datetime_35_months_ago}
         criteria_one = {"account_creation_date": _datetime_35_months_ago}
         self.update_test_data(self.user_0, criteria)

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import bcrypt
 from freezegun import freeze_time
@@ -48,7 +48,7 @@ class TestModel(unittest.TestCase):
         update_params = {"account_verified": "true"}
         user.update_user(update_params)
         self.assertTrue(user.account_verified)
-        self.assertEqual(datetime.utcnow(), user.account_verification_date)
+        self.assertEqual(datetime.now(UTC), user.account_verification_date)
 
     def test_update_user_password(self):
         user = User(username="test", account_verified=False, hashed_password="h4$HedPassword")
@@ -210,18 +210,18 @@ class TestModel(unittest.TestCase):
     @freeze_time(TIME_TO_FREEZE)
     def test_user_verifies_email_update_also_updates_verification_timestamp(self):
         user = User(
-            username="test", account_verified=True, account_verification_date=datetime.utcnow() - timedelta(minutes=1)
+            username="test", account_verified=True, account_verification_date=datetime.now(UTC) - timedelta(minutes=1)
         )
         update_params = {"new_username": "another-username", "account_verified": "true"}
         user.update_user(update_params)
         self.assertEqual(user.username, update_params["new_username"])
         self.assertTrue(user.account_verified)
-        self.assertEqual(datetime.utcnow(), user.account_verification_date)
+        self.assertEqual(datetime.now(UTC), user.account_verification_date)
 
     @freeze_time(TIME_TO_FREEZE)
     def test_user_updates_password_does_not_update_verification_timestamp(self):
         password = "password"
-        verification_date = datetime.utcnow() - timedelta(minutes=1)
+        verification_date = datetime.now(UTC) - timedelta(minutes=1)
         user = User(
             username="test",
             account_verified=True,
@@ -235,7 +235,7 @@ class TestModel(unittest.TestCase):
         self.assertEqual(verification_date, user.account_verification_date)
 
     def test_user_unlocks_account_does_not_update_verification_timestamp(self):
-        verification_date = datetime.utcnow() - timedelta(minutes=1)
+        verification_date = datetime.now(UTC) - timedelta(minutes=1)
         user = User(
             username="test", account_verified=True, account_locked=True, account_verification_date=verification_date
         )
@@ -247,18 +247,18 @@ class TestModel(unittest.TestCase):
     @freeze_time(TIME_TO_FREEZE)
     def test_user_dict(self):
         expected_user_dict = {
-            "first_notification": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "first_notification": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
             "second_notification": None,
             "third_notification": None,
             "mark_for_deletion": False,
-            "account_verification_date": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "account_verification_date": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         }
         user = User(
-            first_notification=datetime.utcnow(),
+            first_notification=datetime.now(UTC),
             second_notification=None,
             third_notification=None,
             mark_for_deletion=False,
-            account_verification_date=datetime.utcnow(),
+            account_verification_date=datetime.now(UTC),
         )
 
         self.assertEqual(expected_user_dict, user.to_user_dict())


### PR DESCRIPTION
# What and why?
Updating `datetime.utcnow` usages to `datetime.now(utc)` as it is now deprecated
# How to test?
- deploy this PR to your env
- run acceptance tests
- check the user table in the auth database and the create and login datetime are right
- sign in to frontstage yourself and check the login time has been updated correctly
# Jira
https://jira.ons.gov.uk/browse/RAS-1533